### PR TITLE
Add ~/.remote machine type for Linux servers

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -36,6 +36,8 @@ Touch a marker file before running the installer — this controls which env con
 touch ~/.work      # work machine
 # or
 touch ~/.personal  # personal machine
+# or
+touch ~/.remote    # remote/server (skips Homebrew; see Remote/Server Setup below)
 ```
 
 If neither exists, only the universal config loads. You can switch at any time and re-run `./install`.
@@ -74,6 +76,7 @@ export AWS_DEFAULT_REGION=us-east-1
 ```
 ~/.work exists     → sources env/work.zsh + installs packages/Brewfile.work
 ~/.personal exists → sources env/personal.zsh + installs packages/Brewfile.personal
+~/.remote exists   → sources env/remote.zsh + skips Homebrew/Brewfiles entirely
 neither exists     → only universal config loads
 ```
 
@@ -87,6 +90,61 @@ All files in `zsh/lib/` are sourced automatically by `zshrc.zsh` in alphabetical
 
 - **Neovim** (`config/nvim/`) — lazy.nvim-based IDE setup, used on desktop machines
 - **Vim** (`config/vim/vimrc`) — minimal, no plugins, safe to use on any remote server with stock vim
+
+---
+
+## Remote/Server Setup
+
+For Linux servers accessed via SSH — same muscle memory, no Homebrew required.
+
+### 1. Clone the repo
+
+```sh
+git clone git@github.com:devnall/dotfiles.git --recursive ~/.dotfiles
+```
+
+### 2. Set the remote marker
+
+```sh
+touch ~/.remote
+```
+
+Do this **before** running `./install`. The marker causes Homebrew setup and all Brewfile installs to be skipped entirely.
+
+### 3. Run the installer
+
+```sh
+cd ~/.dotfiles && ./install
+```
+
+This creates all symlinks. Homebrew and Brewfile steps are skipped.
+
+### What you get
+
+| Feature | Behavior |
+|---------|----------|
+| zsh history, dirstack, setopt | all portable |
+| `zsh/lib/aliases.zsh` | Darwin-specific blocks skip via `uname` checks |
+| `zsh/lib/git.zsh` | git aliases work everywhere |
+| `zsh/lib/fzf.zsh` | skips silently if fzf not installed |
+| starship prompt | skips if not installed; falls back to system prompt |
+| zoxide, thefuck | skip if not installed (guarded with `command -v`) |
+| ssh-agent | works; `-K` Keychain flag is Darwin-only |
+| Homebrew PATH | harmless on Linux (`/usr/local` typically exists) |
+| Brewfile installs | skipped via `~/.remote` guard |
+
+### Optional nice-to-haves (single-binary installs)
+
+```sh
+# starship — cross-platform prompt
+curl -sS https://starship.rs/install.sh | sh
+
+# fzf — fuzzy finder
+git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf && ~/.fzf/install
+
+# zoxide — smarter cd
+curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
+```
 
 ---
 
@@ -115,7 +173,8 @@ dotfiles/
 ├── archive/                  # Deprecated scripts — review and cull periodically
 ├── env/
 │   ├── work.zsh              # Sourced when ~/.work exists
-│   └── personal.zsh          # Sourced when ~/.personal exists
+│   ├── personal.zsh          # Sourced when ~/.personal exists
+│   └── remote.zsh            # Sourced when ~/.remote exists (Linux servers)
 ├── packages/
 │   ├── Brewfile.universal    # Installed on every machine
 │   ├── Brewfile.work         # Installed when ~/.work exists

--- a/config/macos/setup-homebrew.sh
+++ b/config/macos/setup-homebrew.sh
@@ -2,6 +2,12 @@
 #
 # Install homebrew and essential packages
 
+# Skip on Linux unless ~/.remote-full opt-in exists
+if [[ "$(uname)" != "Darwin" ]] && [[ ! -f ~/.remote-full ]]; then
+  echo "Skipping Homebrew setup (not Darwin, no ~/.remote-full opt-in)"
+  exit 0
+fi
+
 if ! type brew > /dev/null 2>&1; then
   echo "Installing Homebrew..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/env/remote.zsh
+++ b/env/remote.zsh
@@ -1,0 +1,26 @@
+# Remote/server shell config — sourced when ~/.remote marker exists
+# Goal: muscle-memory-friendly, zero external dependencies required
+
+# System ls fallback (no eza on most servers)
+if ! command -v eza > /dev/null; then
+  alias l='ls -lahF'
+  alias ll='ls -lahF'
+  alias lt='ls -lahFt'
+fi
+
+# bat fallback to cat if not available
+if ! command -v bat > /dev/null; then
+  alias batp='cat'
+fi
+
+# fzf key bindings if available (can be installed as a single binary on Linux)
+if command -v fzf > /dev/null; then
+  [ -f /usr/share/doc/fzf/examples/key-bindings.zsh ] && \
+    source /usr/share/doc/fzf/examples/key-bindings.zsh
+fi
+
+# Simple prompt fallback if starship isn't installed
+# (starship can be installed on Linux as a single curl | sh)
+if ! command -v starship > /dev/null; then
+  autoload -U promptinit && promptinit 2>/dev/null || true
+fi

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -56,11 +56,11 @@
 - shell:
     - [git submodule update --init --recursive, Installing submodules]
     -
-     command: ./config/macos/setup-homebrew.sh
+     command: '[[ ! -f ~/.remote ]] && ./config/macos/setup-homebrew.sh || true'
      description: Installing Homebrew and essential packages
      stdout: true
     -
-     command: brew bundle --file=packages/Brewfile.universal
+     command: '[[ ! -f ~/.remote ]] && brew bundle --file=packages/Brewfile.universal || true'
      description: Install universal Homebrew packages
      stdout: true
     -

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -56,11 +56,11 @@
 - shell:
     - [git submodule update --init --recursive, Installing submodules]
     -
-     command: '[[ ! -f ~/.remote ]] && ./config/macos/setup-homebrew.sh || true'
+     command: '([[ "$(uname)" == "Darwin" ]] || [[ -f ~/.remote-full ]]) && ./config/macos/setup-homebrew.sh || true'
      description: Installing Homebrew and essential packages
      stdout: true
     -
-     command: '[[ ! -f ~/.remote ]] && brew bundle --file=packages/Brewfile.universal || true'
+     command: '([[ "$(uname)" == "Darwin" ]] || [[ -f ~/.remote-full ]]) && brew bundle --file=packages/Brewfile.universal || true'
      description: Install universal Homebrew packages
      stdout: true
     -

--- a/zsh/zshrc.zsh
+++ b/zsh/zshrc.zsh
@@ -56,6 +56,8 @@ if [[ -f "${HOME}/.work" ]]; then
   [[ -f "${DOTFILES}/env/work.zsh" ]] && source "${DOTFILES}/env/work.zsh"
 elif [[ -f "${HOME}/.personal" ]]; then
   [[ -f "${DOTFILES}/env/personal.zsh" ]] && source "${DOTFILES}/env/personal.zsh"
+elif [[ -f "${HOME}/.remote" ]]; then
+  [[ -f "${DOTFILES}/env/remote.zsh" ]] && source "${DOTFILES}/env/remote.zsh"
 fi
 
 export EDITOR="vim"
@@ -79,7 +81,11 @@ source "${HOME}"/.config/zsh/zfunctions/clipboard
 
 # Load ssh-agent and add private key because OSX
 eval "$(ssh-agent -s)" &> /dev/null
-ssh-add -K ~/.ssh/id_rsa &> /dev/null
+if [[ "$(uname)" == "Darwin" ]]; then
+  ssh-add -K ~/.ssh/id_rsa &> /dev/null
+else
+  ssh-add ~/.ssh/id_rsa &> /dev/null
+fi
 
 # Starship prompt
 if [[ $- == *i* ]]; then


### PR DESCRIPTION
## Summary

- Adds `~/.remote` marker file support (symmetric with `~/.work` / `~/.personal`) for remote Linux servers accessed via SSH
- Creates `env/remote.zsh` with graceful fallbacks for missing tools (ls, bat, fzf, starship)
- Guards `ssh-add -K` to Darwin only (errors on Linux)
- Documents the full remote setup workflow in RUNBOOK.md

**Homebrew guard improvement** (follow-up to the original commit):
- Replaces fragile `~/.remote` Homebrew guard with OS-based detection + explicit opt-in
- Linux: Homebrew skipped by default (no marker needed)
- Linux with `~/.remote-full`: opts into Linuxbrew explicitly
- macOS: always installs (unchanged)
- `setup-homebrew.sh` is now self-guarding — safe even if called directly or YAML guard is bypassed

## Environment separation

| Marker | Effect |
|--------|--------|
| `~/.work` | sources `env/work.zsh` + installs `Brewfile.work` |
| `~/.personal` | sources `env/personal.zsh` + installs `Brewfile.personal` |
| `~/.remote` | sources `env/remote.zsh` (Linux server env config) |
| `~/.remote-full` | opts into Linuxbrew on Linux servers |

## Homebrew behavior

| Machine | `~/.remote-full`? | Result |
|---------|:-----------------:|--------|
| macOS (any) | — | ✅ installs normally |
| Linux server | — | ⛔ skipped |
| Linux server | ✓ | ✅ Linuxbrew installs |

## Test plan

- [ ] `touch ~/.remote && zsh -c 'echo test'` — should output `test` with no errors
- [ ] `source ~/.zshrc` exits 0 on macOS with `~/.remote` present
- [ ] `rm ~/.remote` — normal macOS shell startup unaffected
- [ ] On Linux without opt-in: clone, `./install` — Homebrew steps skipped
- [ ] On Linux with opt-in: `touch ~/.remote-full`, `./install` — Linuxbrew installs
- [ ] macOS: `./install` — Homebrew installs normally (unchanged)
- [ ] Direct call: `./config/macos/setup-homebrew.sh` on Linux — prints skip message, exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)