### PR TITLE
Add remote systems support and remote starship prompt

### DIFF
--- a/config/starship/starship-remote.toml
+++ b/config/starship/starship-remote.toml
@@ -87,7 +87,7 @@ symbol = "ﴱ"
 
 [hostname]
 ssh_only = true
-format = "[$ssh_symbol$hostname] "
+format = "[$ssh_symbol$hostname]($style) "
 ssh_symbol = " "
 
 [jobs]

--- a/config/starship/starship-remote.toml
+++ b/config/starship/starship-remote.toml
@@ -1,0 +1,111 @@
+# Spaceship Prompt Config — remote/server variant
+#
+# Requires a nerd font
+
+add_newline = true
+
+format = """
+$username\
+$hostname\
+$directory\
+$git_branch\
+$git_commit\
+$git_state\
+$git_metrics\
+$git_status\
+$docker_context\
+$golang\
+$helm\
+$python\
+$ruby\
+$terraform\
+$vagrant\
+$aws\
+$env_var\
+$custom\
+$cmd_duration\
+$line_break\
+$jobs\
+$time\
+$status\
+$shell\
+$character"""
+
+[aws]
+symbol = " "
+style = "bold yellow"
+
+[character]
+success_symbol = "[❯](bold blue)[❯](bold cyan)[❯](bold green)"
+error_symbol = "[✖](bold red)[✖](bold red)[❯](bold red)"
+vicmd_symbol ="[](bold green)[❯](bold blue)"
+
+[cmd_duration]
+show_notifications = false
+min_time_to_notify = 30_000
+
+[directory]
+truncation_length = 5
+read_only = ""
+read_only_style = "bold red"
+home_symbol = " ~"
+
+[directory.substitutions]
+" ~/" = "~/"
+
+[docker_context]
+symbol = " "
+style = "bold blue"
+
+[git_branch]
+format = "[$symbol on $branch(:$remote_branch) ]($style)"
+symbol = ""
+style = "bold green"
+
+[git_metrics]
+disabled = false
+added_style = "green"
+
+[git_status]
+style = "white dimmed"
+conflicted = ""
+ahead = ""
+behind = ""
+diverged = "נּ"
+untracked = ""
+stashed = ""
+modified = ""
+staged = ""
+renamed = ""
+deleted = ""
+
+[golang]
+symbol = ""
+
+[helm]
+symbol = "ﴱ"
+
+[hostname]
+ssh_only = true
+format = "[$ssh_symbol$hostname ]"
+ssh_symbol = " "
+
+[jobs]
+symbol = " "
+style = "bold red"
+
+[kubernetes]
+disabled = true
+
+[python]
+symbol = " "
+style = "green"
+
+[ruby]
+symbol = " "
+
+[terraform]
+symbol = "TF  "
+
+[package]
+disabled = true

--- a/config/starship/starship-remote.toml
+++ b/config/starship/starship-remote.toml
@@ -87,7 +87,7 @@ symbol = "ﴱ"
 
 [hostname]
 ssh_only = true
-format = "[$ssh_symbol$hostname ]"
+format = "[$ssh_symbol$hostname] "
 ssh_symbol = " "
 
 [jobs]

--- a/config/starship/starship.toml
+++ b/config/starship/starship.toml
@@ -91,7 +91,7 @@ symbol = "ﴱ"
 
 [hostname]
 ssh_only = true
-format = "[$ssh_symbol$hostname ]"
+format = "[$ssh_symbol$hostname]($style) "
 ssh_symbol = " "
 
 [jobs]

--- a/config/starship/starship.toml
+++ b/config/starship/starship.toml
@@ -103,8 +103,6 @@ disabled = false
 symbol = "ﴱ"
 style    = "fg:#3DA2FF"       # kube-ish bright blue
 format   = "[$symbol $context:$namespace]($style) "
-# only show if auth'ed to AWS
-detect_env_vars = ['AWS_VAULT']
 
 [[kubernetes.contexts]]
 context_pattern = "prod"

--- a/env/remote-full.zsh
+++ b/env/remote-full.zsh
@@ -1,0 +1,4 @@
+# Remote-full shell config — sourced when ~/.remote-full marker exists
+# For Linux servers with Homebrew and full tool suite installed
+
+export STARSHIP_CONFIG=~/.config/starship-remote.toml

--- a/env/remote.zsh
+++ b/env/remote.zsh
@@ -1,6 +1,8 @@
 # Remote/server shell config — sourced when ~/.remote marker exists
 # Goal: muscle-memory-friendly, zero external dependencies required
 
+export STARSHIP_CONFIG=~/.config/starship-remote.toml
+
 # System ls fallback (no eza on most servers)
 if ! command -v eza > /dev/null; then
   alias l='ls -lahF'

--- a/env/remote.zsh
+++ b/env/remote.zsh
@@ -1,8 +1,6 @@
 # Remote/server shell config — sourced when ~/.remote marker exists
 # Goal: muscle-memory-friendly, zero external dependencies required
 
-export STARSHIP_CONFIG=~/.config/starship-remote.toml
-
 # System ls fallback (no eza on most servers)
 if ! command -v eza > /dev/null; then
   alias l='ls -lahF'

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -43,6 +43,9 @@
     ~/.config/starship.toml:
       path: config/starship/starship.toml
 
+    ~/.config/starship-remote.toml:
+      path: config/starship/starship-remote.toml
+
     ~/.config/bat/config:
       path: config/bat/config
 

--- a/zsh/lib/fzf.zsh
+++ b/zsh/lib/fzf.zsh
@@ -23,7 +23,7 @@ fi
 
 # Shell integration
 # -----------------
-source <(fzf --zsh)
+source <(fzf --zsh 2>/dev/null)
 
 # Command keybinds
 # ----------------

--- a/zsh/zshrc.zsh
+++ b/zsh/zshrc.zsh
@@ -56,6 +56,8 @@ if [[ -f "${HOME}/.work" ]]; then
   [[ -f "${DOTFILES}/env/work.zsh" ]] && source "${DOTFILES}/env/work.zsh"
 elif [[ -f "${HOME}/.personal" ]]; then
   [[ -f "${DOTFILES}/env/personal.zsh" ]] && source "${DOTFILES}/env/personal.zsh"
+elif [[ -f "${HOME}/.remote-full" ]]; then
+  [[ -f "${DOTFILES}/env/remote-full.zsh" ]] && source "${DOTFILES}/env/remote-full.zsh"
 elif [[ -f "${HOME}/.remote" ]]; then
   [[ -f "${DOTFILES}/env/remote.zsh" ]] && source "${DOTFILES}/env/remote.zsh"
 fi

--- a/zsh/zshrc.zsh
+++ b/zsh/zshrc.zsh
@@ -81,12 +81,10 @@ fi
 source "${HOME}"/.config/zsh/zfunctions/color_list
 source "${HOME}"/.config/zsh/zfunctions/clipboard
 
-# Load ssh-agent and add private key because OSX
-eval "$(ssh-agent -s)" &> /dev/null
+# Load ssh-agent and add private key (macOS only)
 if [[ "$(uname)" == "Darwin" ]]; then
+  eval "$(ssh-agent -s)" &> /dev/null
   ssh-add -K ~/.ssh/id_rsa &> /dev/null
-else
-  ssh-add ~/.ssh/id_rsa &> /dev/null
 fi
 
 # Starship prompt


### PR DESCRIPTION
## Summary

- Adds `~/.remote` machine type for minimal Linux servers (skips Homebrew, provides ls/bat/fzf fallbacks)
- Adds `~/.remote-full` machine type for Linux servers with full Homebrew setup
- Adds a server-optimized starship config (`starship-remote.toml`) that activates automatically on `~/.remote-full` hosts via `STARSHIP_CONFIG` in `env/remote-full.zsh`
- Fixes starship hostname format string bug in both configs (trailing space inside brackets, missing `($style)`)
- Fixes `fzf --zsh` erroring silently on older fzf versions
- Restricts `ssh-agent` startup to macOS only (was spawning orphaned agents and prompting for passphrase on Linux)
- Removes unsupported `detect_env_vars` from the kubernetes starship module

## Test plan

- [x] `~/.remote`: `env/remote.zsh` sourced, no `STARSHIP_CONFIG` set, no startup errors
- [x] `~/.remote-full`: `env/remote-full.zsh` sourced, `STARSHIP_CONFIG=~/.config/starship-remote.toml`, starship renders with hostname and no kubernetes module
- [x] macOS unaffected: `STARSHIP_CONFIG` unset, main starship config loads with kubernetes context-awareness intact
- [x] No starship WARN output on any configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)