### PR TITLE
Final docs review for Phase 8

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,6 +51,10 @@ dotfiles/
     ├── btop/
     ├── ghostty/
     ├── git/
+    │   ├── config            # Git config (symlinked to ~/.gitconfig)
+    │   ├── ignore            # Global gitignore
+    │   ├── .gitconfig-user.example  # Template for git identity (copy to .gitconfig-user)
+    │   └── .gitconfig-user   # Local git identity (gitignored)
     ├── macos/                # macOS setup/defaults scripts
     ├── nvim/                 # Neovim config (lazy.nvim)
     ├── ripgrep/
@@ -78,7 +82,8 @@ dotfiles/
 - **Primary:** macOS with zsh. Only fully-supported interactive shell environment.
 - **Remote baseline:** `config/bash/bashrc` provides a minimal `.bashrc` for remote servers — PATH, essential aliases only. No visual elements, does not mirror the full zsh setup.
 - **Entrypoint:** `zsh/zshrc.zsh` is the sole zsh entrypoint. It sources `zsh/lib/*.zsh` directly — no `shell/`, `os/`, or `env/` module tree.
-- **Plugin manager:** Sheldon (`config/sheldon/`) manages zsh plugins. Homebrew dependency. Initialization guarded with `command -v sheldon > /dev/null`.
+- **Plugin manager:** Sheldon (`config/sheldon/`) manages zsh plugins. Homebrew dependency. Initialization guarded with `command -v sheldon > /dev/null && [[ -t 1 ]]`.
+- **Optional tool guards:** Tools that may not be installed on all machines (zoxide, thefuck, terraform, bat) are guarded with `command -v` checks. The installer's `bat cache --build` step is similarly guarded.
 
 ### 3.3 Machine-Specific PATH
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -98,7 +98,7 @@ export AWS_DEFAULT_REGION=us-east-1
 ```
 ~/.work exists         → sources env/work.zsh + installs packages/Brewfile.work
 ~/.personal exists     → sources env/personal.zsh + installs packages/Brewfile.personal
-~/.remote-full exists  → sources env/remote-full.zsh (Linux server with Homebrew + full tool suite)
+~/.remote-full exists  → sources env/remote-full.zsh + installs packages/Brewfile.universal
 ~/.remote exists       → sources env/remote.zsh + skips Homebrew/Brewfiles entirely
 none exists            → only universal config loads
 ```
@@ -156,6 +156,8 @@ cd ~/.dotfiles && ./install
 
 This creates all symlinks. Homebrew and Brewfile steps are skipped.
 
+**Prerequisites:** `git`, `zsh`, and `python3` must be installed (python3 is required by dotbot).
+
 ### What you get
 
 | Feature | Behavior |
@@ -165,7 +167,8 @@ This creates all symlinks. Homebrew and Brewfile steps are skipped.
 | `zsh/lib/git.zsh` | git aliases work everywhere |
 | `zsh/lib/fzf.zsh` | skips silently if fzf not installed |
 | starship prompt | skips if not installed; falls back to system prompt |
-| zoxide, thefuck | skip if not installed (guarded with `command -v`) |
+| zoxide, thefuck, terraform completions | skip if not installed (guarded with `command -v`) |
+| bat theme cache | skips if bat not installed |
 | Homebrew PATH | harmless on Linux (`/usr/local` typically exists) |
 | Brewfile installs | skipped via `~/.remote` guard |
 
@@ -236,7 +239,7 @@ dotfiles/
     ├── bat/
     ├── btop/
     ├── ghostty/
-    ├── git/
+    ├── git/                  # Git config + identity template (.gitconfig-user.example)
     ├── macos/                # macOS setup scripts
     ├── nvim/                 # Neovim config (lazy.nvim)
     ├── ripgrep/


### PR DESCRIPTION
## Summary

- Update ARCHITECTURE.md: expand git/ directory tree with identity template files, document sheldon's `[[ -t 1 ]]` guard, add optional tool guards section (zoxide, thefuck, terraform, bat)
- Update RUNBOOK.md: fix remote-full Brewfile behavior description, add python3 prerequisite for remote deploys, add bat/terraform to remote portability table, annotate git/ in directory tree

## Test plan

- [x] Docs-only changes — no code modified
- [x] Verified all claims against actual repo state

🤖 Generated with [Claude Code](https://claude.com/claude-code)