### PR TITLE
Migrate to mise as unified runtime manager

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,7 +88,7 @@ dotfiles/
 
 ### 3.3 Machine-Specific PATH
 
-- **Universal toolchain paths** (Homebrew, Cargo, Go): defined in `zsh/lib/path.zsh`, guarded with `[[ -d /path ]]` checks. Ruby and Node paths are handled by mise, not manually.
+- **Universal toolchain paths** (Homebrew, Cargo, Go user binaries): defined in `zsh/lib/path.zsh`, guarded with `[[ -d /path ]]` checks. Ruby, Node, and language runtime paths are handled by mise, not manually.
 - **Machine-specific tools** (e.g., LM Studio, Claude Code): go in `~/.env.local`, NOT committed to the repo.
 
 ### 3.4 Environment Separation (Marker Files)
@@ -104,7 +104,7 @@ dotfiles/
 
 ### 3.7 Runtime Management (mise)
 
-- [mise](https://mise.jdx.dev/) is the single runtime manager for language toolchains: lua, node, python, ruby, terraform.
+- [mise](https://mise.jdx.dev/) is the single runtime manager for language toolchains: go, lua, node, python, ruby, terraform.
 - Global config lives in `config/mise/config.toml`, symlinked to `~/.config/mise/config.toml` via dotbot.
 - Activated in `zshrc.zsh` via `eval "$(mise activate zsh)"`, guarded with `command -v mise`.
 - Per-project overrides: drop a `.mise.toml` in the project root to pin specific versions.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,6 +56,7 @@ dotfiles/
     │   ├── .gitconfig-user.example  # Template for git identity (copy to .gitconfig-user)
     │   └── .gitconfig-user   # Local git identity (gitignored)
     ├── macos/                # macOS setup/defaults scripts
+    ├── mise/                 # Runtime version manager config
     ├── nvim/                 # Neovim config (lazy.nvim)
     ├── ripgrep/
     ├── sheldon/              # Zsh plugin manager config
@@ -87,7 +88,7 @@ dotfiles/
 
 ### 3.3 Machine-Specific PATH
 
-- **Universal toolchain paths** (Homebrew, Cargo, Go, Ruby gems): defined in `zsh/lib/path.zsh`, guarded with `[[ -d /path ]]` checks.
+- **Universal toolchain paths** (Homebrew, Cargo, Go): defined in `zsh/lib/path.zsh`, guarded with `[[ -d /path ]]` checks. Ruby and Node paths are handled by mise, not manually.
 - **Machine-specific tools** (e.g., LM Studio, Claude Code): go in `~/.env.local`, NOT committed to the repo.
 
 ### 3.4 Environment Separation (Marker Files)
@@ -100,6 +101,15 @@ dotfiles/
   - `~/.personal` — personal machine (full macOS setup)
   - `~/.remote-full` — Linux server with Homebrew and full tool suite
   - `~/.remote` — minimal Linux server (no Homebrew; skips Brewfiles entirely)
+
+### 3.7 Runtime Management (mise)
+
+- [mise](https://mise.jdx.dev/) is the single runtime manager for language toolchains: lua, node, python, ruby, terraform.
+- Global config lives in `config/mise/config.toml`, symlinked to `~/.config/mise/config.toml` via dotbot.
+- Activated in `zshrc.zsh` via `eval "$(mise activate zsh)"`, guarded with `command -v mise`.
+- Per-project overrides: drop a `.mise.toml` in the project root to pin specific versions.
+- **Rust** is managed by rustup, not mise (standard practice for the Rust ecosystem).
+- Legacy managers (nvm, rbenv, tfenv) are quarantined in Brewfiles — mise replaces all of them.
 
 ### 3.5 Secrets Management
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -74,7 +74,17 @@ Then edit `~/.dotfiles/config/git/.gitconfig-user`:
 
 This file is excluded from git tracking. The template (`.gitconfig-user.example`) is what's committed to the repo.
 
-### 6. Set up local overrides
+### 6. Install runtimes (mise)
+
+After the installer runs, mise is activated but runtimes aren't installed yet:
+
+```sh
+mise install
+```
+
+This installs all tools defined in `~/.config/mise/config.toml` (lua, node, python, ruby, terraform). Verify with `mise ls`.
+
+### 7. Set up local overrides
 
 Create these files — both are gitignored and sourced at the end of every shell session:
 
@@ -241,6 +251,7 @@ dotfiles/
     ├── ghostty/
     ├── git/                  # Git config + identity template (.gitconfig-user.example)
     ├── macos/                # macOS setup scripts
+    ├── mise/                 # Runtime version manager config
     ├── nvim/                 # Neovim config (lazy.nvim)
     ├── ripgrep/
     ├── sheldon/              # Zsh plugin manager config
@@ -286,6 +297,26 @@ git commit -m "update dotbot submodule"
 ```sh
 nvim --headless "+Lazy sync" +qa
 ```
+
+### Update mise runtimes
+
+```sh
+mise upgrade        # upgrade all installed runtimes to latest
+mise ls             # show currently installed versions
+mise doctor         # health check
+```
+
+### Pin a runtime version per-project
+
+Drop a `.mise.toml` in the project root:
+
+```toml
+[tools]
+node = "20"
+python = "3.12"
+```
+
+Then run `mise install` in that directory. mise activates the correct versions automatically when you `cd` into the project.
 
 ### Update sheldon plugins
 

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -82,7 +82,7 @@ After the installer runs, mise is activated but runtimes aren't installed yet:
 mise install
 ```
 
-This installs all tools defined in `~/.config/mise/config.toml` (lua, node, python, ruby, terraform). Verify with `mise ls`.
+This installs all tools defined in `~/.config/mise/config.toml` (go, lua, node, python, ruby, terraform). Verify with `mise ls`.
 
 ### 7. Set up local overrides
 

--- a/TODO.md
+++ b/TODO.md
@@ -57,3 +57,7 @@ Items that came up during cleanup project planning but are out of scope for the 
 ## Shell Utilities
 
 - **Custom tealdeer pages** — Investigate whether tealdeer supports custom/local page overrides for documenting personal aliases and cheatsheet entries alongside community pages.
+
+## Performance
+
+- **Shell startup time audit** — Benchmark shell startup time on all primary machines (personal desktop, personal laptop, work laptop) using the RUNBOOK method. Target is under ~500ms warm. One laptop is currently 590–690ms after the mise migration. Profile with `zsh -x` or `zprof` to identify the slowest contributors and optimize if needed. **This should be one of the last TODOs worked from this list** — let other changes land first so the audit captures the final steady-state.

--- a/TODO.md
+++ b/TODO.md
@@ -50,10 +50,6 @@ Items that came up during cleanup project planning but are out of scope for the 
 - **Manage ssh.local via 1Password** — Investigate storing per-machine `~/.ssh/config.local` files in 1Password and deploying them with the `op` CLI.
 - **Secrets management for env/work.zsh** — Replace hardcoded profile names in `env/work.zsh` with variables; keep real values in a secrets file managed by 1Password CLI. Document the workflow.
 
-## Runtime Management
-
-- **Migrate to mise** — First-class requirement. Scope: python, ruby, rust (currently Homebrew or ad-hoc), tfenv/tenv (terraform), nvm (node), rbenv (ruby). Goal: mise as single source of truth for all language runtimes. Once migrated, remove redundant version managers and Homebrew-managed language packages from Brewfiles.
-
 ## Applications
 
 - **Audit installed applications** — On each primary machine (personal desktop, personal laptop, work laptop), audit `/Applications` and `~/Applications`. Sort everything into the universal/work/personal Brewfile pattern. For apps only available via the Mac App Store, either automate with the `mas` CLI or document the manual install steps.

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -1,4 +1,5 @@
 [tools]
+go = "latest"
 lua = "latest"
 node = "latest"
 python = "latest"

--- a/config/mise/config.toml
+++ b/config/mise/config.toml
@@ -1,0 +1,6 @@
+[tools]
+lua = "latest"
+node = "latest"
+python = "latest"
+ruby = "latest"
+terraform = "latest"

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -51,6 +51,10 @@
     ~/.config/starship-remote.toml:
       path: config/starship/starship-remote.toml
 
+    ~/.config/mise/config.toml:
+      path: config/mise/config.toml
+      force: true
+
     ~/.ripgreprc:
       path: config/ripgrep/.ripgreprc
 

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -74,7 +74,6 @@ brew "mkcert"         # local HTTPS certs
 brew "shellcheck"
 
 # Languages
-brew "go"
 # brew "python"       # managed via mise
 # brew "ruby"         # managed via mise
 # brew "rust"         # managed via rustup/mise
@@ -117,6 +116,7 @@ cask "vlc"
 # cask "keepingyouawake"       # 20260313
 # cask "pika"                  # color picker — 20260313
 # cask "shottr"                # screenshot tool — 20260313
+# brew "go"                     # 20260316 — migrated to mise
 # brew "node"                   # 20260316 — migrated to mise
 # brew "nvm"                    # 20260316 — migrated to mise
 # brew "rbenv"                  # 20260316 — migrated to mise

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -75,9 +75,6 @@ brew "shellcheck"
 
 # Languages
 brew "go"
-brew "node"
-brew "nvm"
-brew "rbenv"          # Ruby version manager — TODO: migrate to mise
 # brew "python"       # managed via mise
 # brew "ruby"         # managed via mise
 # brew "rust"         # managed via rustup/mise
@@ -120,4 +117,7 @@ cask "vlc"
 # cask "keepingyouawake"       # 20260313
 # cask "pika"                  # color picker — 20260313
 # cask "shottr"                # screenshot tool — 20260313
+# brew "node"                   # 20260316 — migrated to mise
+# brew "nvm"                    # 20260316 — migrated to mise
+# brew "rbenv"                  # 20260316 — migrated to mise
 # cask "vscodium"              # 20260313

--- a/zsh/lib/path.zsh
+++ b/zsh/lib/path.zsh
@@ -13,17 +13,6 @@ if [ -d "${HOME}/go/bin" ]; then
   PATH="${HOME}/go/bin:${PATH}"
 fi
 
-# gem-installed stuff — find the newest installed Ruby gem bin dir
-for ruby_gem_bin in "${HOME}"/.gem/ruby/*/bin(N); do
-  PATH="${PATH}:${ruby_gem_bin}"
-done
-unset ruby_gem_bin
-
-# npm global packages
-if [ -d "${HOME}/.npm-packages/bin" ]; then
-  PATH="${PATH}:${HOME}/.npm-packages/bin"
-fi
-
 # My ~/bin dir
 if [ -d "${HOME}/bin" ]; then
   PATH="${HOME}/bin:${PATH}"

--- a/zsh/zshrc.zsh
+++ b/zsh/zshrc.zsh
@@ -16,6 +16,10 @@ if [ -z "$(echo $PATH | grep -o $HOMEBREW_PREFIX/bin)" ]; then
   export PATH="$HOMEBREW_PREFIX/sbin:$HOMEBREW_PREFIX/bin:$PATH"
 fi
 
+if command -v mise > /dev/null; then
+  eval "$(mise activate zsh)"
+fi
+
 ## History config
 HISTFILE="${HOME}/.zsh_history"
 HISTSIZE="50000"
@@ -91,7 +95,7 @@ fi
 
 if [[ -t 1 ]] && command -v terraform > /dev/null; then
   autoload -U +X bashcompinit && bashcompinit
-  complete -o nospace -C $HOMEBREW_PREFIX/bin/terraform terraform
+  complete -o nospace -C "$(command -v terraform)" terraform
 fi
 
 if command -v zoxide > /dev/null; then


### PR DESCRIPTION
## Summary
- Configure mise to manage lua, node, python, ruby, and terraform (all `latest` in global config)
- Add shell activation in zshrc, dotbot symlink, and terraform completion fix (`command -v` instead of hardcoded Homebrew path)
- Remove ruby gem and npm PATH entries from `path.zsh` (mise handles these now)
- Quarantine legacy version managers (nvm, rbenv, node) in Brewfile.universal
- Update ARCHITECTURE.md, RUNBOOK.md, and TODO.md

## Test plan
- [x] Run `./install` to apply dotbot symlink
- [x] `mise install` and `mise reshim` to install runtimes and create shims
- [x] `mise doctor` shows healthy status (activation warning is a false positive outside interactive shell)
- [x] `which node`, `which python`, `which ruby`, `which terraform` all point to mise installs
- [x] Terraform tab completion works
- [x] Starship prompt detects versions in projects
- [x] Tested on all primary machines (personal desktop, personal laptop, work laptop)
- [ ] Shell startup time on one laptop is 590–690ms (TODO added to audit later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)