### PR TITLE
Triage 1Password TODOs, add op CLI runbook section

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -1,8 +1,4 @@
 {
-  "statusLine": {
-    "type": "command",
-    "command": "bash ~/.claude/statusline-command.sh"
-  },
   "hooks": {
     "SessionStart": [
       {
@@ -16,6 +12,10 @@
       }
     ]
   },
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.claude/statusline-command.sh"
+  },
   "enabledPlugins": {
     "frontend-design@claude-plugins-official": true
   },
@@ -26,5 +26,6 @@
         "repo": "anthropics/claude-code"
       }
     }
-  }
+  },
+  "model": "opus"
 }

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -135,6 +135,24 @@ Host myalias
   ForwardAgent yes
 ```
 
+### 1Password CLI (`op`)
+
+The `op` CLI is installed via Homebrew and shell completions are wired in `zsh/lib/completions.zsh`.
+
+**Common commands:**
+
+```sh
+op vault list                          # list available vaults
+op item list                           # list all items
+op item list --vault Private           # list items in a specific vault
+op item get "Item Name"                # show full item details
+op read "op://VaultName/Item/field"    # read a single secret value (scriptable)
+```
+
+**SSH agent integration:** The 1Password SSH agent is configured in `config/ssh/config` via `IdentityAgent` — see the [SSH config](#ssh-config) section above. Keys are managed in 1Password and served to SSH transparently.
+
+**Touch ID / biometric prompts:** The `op` CLI and SSH agent trigger macOS biometric prompts (Touch ID or password) when accessing secrets. This is expected 1Password security behavior, not a bug or misconfiguration.
+
 ### Editors
 
 - **Neovim** (`config/nvim/`) — lazy.nvim-based IDE setup, used on desktop machines

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -41,9 +41,9 @@ _Done: palette reference doc (`docs/color-palettes.md`), btop NordicPine theme, 
 
 ## 1Password & Secrets
 
-- **Learn the `op` CLI** — Figure out the 1Password CLI tool and resolve the recurring permissions popups.
-- **Manage ssh.local via 1Password** — Investigate storing per-machine `~/.ssh/config.local` files in 1Password and deploying them with the `op` CLI.
-- **Secrets management for env/work.zsh** — Replace hardcoded profile names in `env/work.zsh` with variables; keep real values in a secrets file managed by 1Password CLI. Document the workflow.
+- ~~**Learn the `op` CLI**~~ — Done. `op` CLI installed, completions wired, reference added to RUNBOOK. Permissions popups are expected Touch ID behavior.
+- **Manage ssh.local via 1Password** — Deferred/aspirational. No active pain point; `~/.ssh/config.local` is fine as a local file.
+- ~~**Secrets management for env/work.zsh**~~ — Closed. Profile names assessed as not sensitive enough to warrant extraction. If this changes, `op read` + `~/.secrets.local` is the documented pattern.
 
 ## Applications
 


### PR DESCRIPTION
## Summary
- Close resolved 1Password TODO items (op CLI learned, secrets management assessed as not needed)
- Defer ssh.local 1Password management as aspirational/no active pain point
- Add `op` CLI reference section to RUNBOOK (common commands, SSH agent, Touch ID note)
- Set Claude model preference to opus, reorder settings keys

## Test plan
- [ ] Verify RUNBOOK renders correctly on GitHub
- [ ] Verify TODO strikethroughs render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)