### PR TITLE
✨ SSH commit signing + includeIf identity switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,8 +74,9 @@ Thumbs.db
 *secrets*
 *.key
 
-# Git identity (copy from .gitconfig-user.example; keep untracked)
+# Git identity (copy from .gitconfig-*.example; keep untracked)
 config/git/.gitconfig-user
+config/git/.gitconfig-work
 
 # Live theme-switched configs (mutable at runtime, initialized from *.default)
 config/btop/btop.conf

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -141,7 +141,45 @@ else
   fi
 fi
 
-# --- 6. Stub files ---
+# --- 6. Code directories ---
+
+if [[ -d "$HOME/code/personal" ]]; then
+  skip "~/code/personal/"
+else
+  mkdir -p "$HOME/code/personal"
+  success "Created ~/code/personal/"
+fi
+
+if [[ -f "$HOME/.work" ]]; then
+  if [[ -d "$HOME/code/work" ]]; then
+    skip "~/code/work/"
+  else
+    mkdir -p "$HOME/code/work"
+    success "Created ~/code/work/"
+  fi
+fi
+
+# --- 7. Work git identity template ---
+
+if [[ -f "$HOME/.work" ]]; then
+  GITCONFIG_WORK="$DOTFILES_DIR/config/git/.gitconfig-work"
+  GITCONFIG_WORK_EXAMPLE="$DOTFILES_DIR/config/git/.gitconfig-work.example"
+
+  if [[ -f "$GITCONFIG_WORK" ]]; then
+    skip "Git work identity (config/git/.gitconfig-work)"
+    info "Verify your work name, email, and signingkey are current"
+  else
+    if [[ -f "$GITCONFIG_WORK_EXAMPLE" ]]; then
+      cp "$GITCONFIG_WORK_EXAMPLE" "$GITCONFIG_WORK"
+      success "Created config/git/.gitconfig-work from template"
+      warn "Edit config/git/.gitconfig-work with your work name, email, and signingkey"
+    else
+      error "Template not found: config/git/.gitconfig-work.example"
+    fi
+  fi
+fi
+
+# --- 8. Stub files ---
 
 create_stub() {
   local filepath="$1"
@@ -187,7 +225,7 @@ create_stub "$HOME/.ssh/config.local" \
 #     ForwardAgent yes" \
 "~/.ssh/config.local"
 
-# --- 7. Mise runtimes ---
+# --- 9. Mise runtimes ---
 
 if command -v mise &>/dev/null; then
   read -rp "[→] Run mise install to provision runtimes? [Y/n]: " yn
@@ -200,7 +238,7 @@ if command -v mise &>/dev/null; then
   fi
 fi
 
-# --- 8. Summary ---
+# --- 10. Summary ---
 
 printf '\n%s=== Bootstrap complete ===%s\n\n' "$BOLD" "$RESET"
 
@@ -213,6 +251,13 @@ fi
 if [[ -f "$GITCONFIG_USER" ]] && grep -q 'Your Name' "$GITCONFIG_USER" 2>/dev/null; then
   todos+=("Edit config/git/.gitconfig-user with your name, email, and signingkey")
 fi
+if [[ -f "$HOME/.work" ]]; then
+  GITCONFIG_WORK="${GITCONFIG_WORK:-$DOTFILES_DIR/config/git/.gitconfig-work}"
+  if [[ -f "$GITCONFIG_WORK" ]] && grep -q 'Your Name' "$GITCONFIG_WORK" 2>/dev/null; then
+    todos+=("Edit config/git/.gitconfig-work with your work name, email, and signingkey")
+  fi
+fi
+todos+=("Set up commit signing with 1Password SSH keys — see docs/RUNBOOK.md")
 if [[ -f "$HOME/.env.local" ]] && ! grep -qv '^#' "$HOME/.env.local" 2>/dev/null; then
   todos+=("Add machine-specific config to ~/.env.local")
 fi

--- a/config/git/.gitconfig-user.example
+++ b/config/git/.gitconfig-user.example
@@ -1,7 +1,11 @@
 # Personal identity template — copy to .gitconfig-user and fill in your values
 # .gitconfig-user is gitignored; this example file is what's committed
 # config/git/config includes ~/.dotfiles/config/git/.gitconfig-user via [include]
+#
+# signingkey should be your SSH public key string from 1Password:
+#   1Password app → SSH key item → copy public key
+# See docs/RUNBOOK.md "Commit Signing with 1Password SSH Keys" for full setup
 [user]
   name = Your Name
   email = you@example.com
-  signingkey = YOUR_SSH_KEY_PATH_OR_GPG_ID
+  signingkey = ssh-ed25519 AAAA...

--- a/config/git/.gitconfig-work.example
+++ b/config/git/.gitconfig-work.example
@@ -1,0 +1,12 @@
+# Work identity template — copy to .gitconfig-work and fill in your values
+# .gitconfig-work is gitignored; this example file is what's committed
+# config/git/config includes this via [includeIf "gitdir:~/code/work/"]
+# Only needed on work machines (those with ~/.work marker)
+#
+# signingkey should be your SSH public key string from 1Password:
+#   1Password app → SSH key item → copy public key
+# See docs/RUNBOOK.md "Commit Signing with 1Password SSH Keys" for full setup
+[user]
+  name = Your Name
+  email = you@work-domain.com
+  signingkey = ssh-ed25519 AAAA...

--- a/config/git/config
+++ b/config/git/config
@@ -27,6 +27,7 @@
   sort = version:refname
 [commit]
   verbose = true
+  gpgsign = true
 [help]
   autocorrect = prompt
 [core]
@@ -65,5 +66,7 @@
   pushInsteadOf = "git://github.com"
 [include]
   path = ~/.dotfiles/config/git/.gitconfig-user
+[includeIf "gitdir:~/code/work/"]
+  path = ~/.dotfiles/config/git/.gitconfig-work
 [gpg]
   format = ssh

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,7 +54,9 @@ dotfiles/
     │   ├── config            # Git config (symlinked to ~/.gitconfig)
     │   ├── ignore            # Global gitignore
     │   ├── .gitconfig-user.example  # Template for git identity (copy to .gitconfig-user)
-    │   └── .gitconfig-user   # Local git identity (gitignored)
+    │   ├── .gitconfig-user   # Local git identity (gitignored)
+    │   ├── .gitconfig-work.example  # Template for work identity (copy to .gitconfig-work)
+    │   └── .gitconfig-work   # Work git identity (gitignored, work machines only)
     ├── macos/                # macOS setup/defaults scripts
     ├── mise/                 # Runtime version manager config
     ├── nvim/                 # Neovim config (lazy.nvim)
@@ -128,6 +130,13 @@ dotfiles/
 - **Neovim** (`config/nvim/`): lazy.nvim-based. Intended for desktop machines. Must open without blocking errors when an LSP or external tool is missing.
 - **Vim** (`config/vim/`): Symlinked as `~/.vim` → `config/vim/`. Must work on any remote server with stock vim and zero external dependencies. Includes `nordicpine` colorscheme (dark/light auto-detection).
 
+### 3.8 Git Identity & Commit Signing
+
+- **Single GitHub account:** One GitHub account for both work and personal. Employer doesn't require separation, and `includeIf`-based identity switching gives correct attribution per repo. Revisit only if employer policy changes.
+- **Identity switching:** `config/git/config` uses `[includeIf "gitdir:~/code/work/"]` to load `.gitconfig-work` (work name, email, signingkey). All other repos use the default `.gitconfig-user` (personal identity). Directory convention: `~/code/work/` for work repos, `~/code/personal/` for personal repos.
+- **Commit signing:** `commit.gpgsign = true` is shared config (in `config/git/config`). `user.signingkey` is per-machine, set in `.gitconfig-user` and `.gitconfig-work`. `gpg.format = ssh` — all machines target 1Password-managed SSH keys for signing.
+- **`allowed_signers`:** Intentionally skipped. GitHub handles signature verification via uploaded signing keys — local verification isn't needed for this workflow.
+
 ---
 
 ## 4. Strict Directives
@@ -184,6 +193,7 @@ These should be true at the end of any project that modifies the repo:
 | `~/.env.local` | Machine-specific exports (gitignored, not in repo) |
 | `~/.secrets.local` | API keys and tokens (gitignored, not in repo) |
 | `config/git/.gitconfig-user` | Git identity (gitignored, copy from `.gitconfig-user.example`) |
+| `config/git/.gitconfig-work` | Work git identity (gitignored, copy from `.gitconfig-work.example`, work machines only) |
 | `README.md` | Quick-start installation guide |
 | `docs/RUNBOOK.md` | Detailed usage, maintenance, and troubleshooting |
 | `SPEC.md` | Current project task plan (rotates per project) |

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -25,6 +25,8 @@ The bootstrap wizard is interactive and idempotent — it skips anything already
 - **Machine type** — prompts you to choose work / personal / remote-full / remote and creates the marker file (`~/.work`, etc.). Controls which env config and Brewfile load at install time
 - **Homebrew** — offers to install on macOS / remote-full machines
 - **Git identity** — copies `config/git/.gitconfig-user.example` → `.gitconfig-user` if missing. Edit this file with your name, email, and signingkey
+- **Code directories** — creates `~/code/personal/` on all machines, `~/code/work/` on work machines only
+- **Work git identity** (work machines only) — copies `config/git/.gitconfig-work.example` → `.gitconfig-work` if missing. Edit with your work name, email, and signingkey
 - **Stub files** — creates `~/.env.local`, `~/.secrets.local`, and `~/.ssh/config.local` with commented templates if they don't exist
 
 ### 3. Run the installer
@@ -51,6 +53,7 @@ Installs all tools defined in `~/.config/mise/config.toml` (go, lua, node, pytho
 |------|---------|
 | `~/.work` / `~/.personal` / `~/.remote-full` / `~/.remote` | Machine type marker (created by bootstrap) |
 | `config/git/.gitconfig-user` | Git identity — name, email, signingkey (gitignored) |
+| `config/git/.gitconfig-work` | Work git identity — work machines only (gitignored) |
 | `~/.env.local` | Machine-specific exports, PATH additions, non-secret config |
 | `~/.secrets.local` | API keys, tokens, credentials — never commit |
 | `~/.ssh/config.local` | Per-machine SSH host entries (not tracked) |
@@ -108,6 +111,44 @@ op read "op://VaultName/Item/field"    # read a single secret value (scriptable)
 **SSH agent integration:** The 1Password SSH agent is configured in `config/ssh/config` via `IdentityAgent` — see the [SSH config](#ssh-config) section above. Keys are managed in 1Password and served to SSH transparently.
 
 **Touch ID / biometric prompts:** The `op` CLI and SSH agent trigger macOS biometric prompts (Touch ID or password) when accessing secrets. This is expected 1Password security behavior, not a bug or misconfiguration.
+
+### Commit Signing with 1Password SSH Keys
+
+All commits are signed (`commit.gpgsign = true` in shared git config, `gpg.format = ssh`). Each machine needs its `user.signingkey` set to the SSH public key string from 1Password.
+
+**Setup (per machine):**
+
+1. Open 1Password → find your SSH key item → copy the public key (starts with `ssh-ed25519 AAAA...`)
+2. Paste it as the `signingkey` value in `config/git/.gitconfig-user`:
+   ```ini
+   [user]
+     name = Your Name
+     email = you@example.com
+     signingkey = ssh-ed25519 AAAA...your-key-here
+   ```
+3. On work machines, do the same in `config/git/.gitconfig-work` with your work email and key
+4. Upload the signing key to GitHub: Settings → SSH and GPG keys → New SSH key → select **Signing Key** as the key type
+5. Verify signing works:
+   ```sh
+   echo "test" | git commit-tree HEAD^{tree}   # should not error
+   git log --show-signature -1                   # or check GitHub for "Verified" badge
+   ```
+
+**Note:** `allowed_signers` is intentionally not configured. GitHub handles signature verification via uploaded signing keys — local `git log --show-signature` won't show "Good signature" without it, but GitHub's Verified badge works.
+
+### Directory Convention (Work / Personal)
+
+Repos are organized by identity under `~/code/`:
+
+```
+~/code/
+├── work/       # Work repos — git uses work identity (name, email, signingkey)
+└── personal/   # Personal repos — git uses personal identity (default)
+```
+
+The `~/code/work/` directory triggers `includeIf` in git config, loading `.gitconfig-work` which overrides `user.name`, `user.email`, and `user.signingkey` for all repos cloned there. Repos anywhere else use the default personal identity from `.gitconfig-user`.
+
+Bootstrap creates these directories automatically (`~/code/work/` only on work machines).
 
 ### Editors
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,10 +4,6 @@ Deferred ideas and future improvements.
 
 ---
 
-## Rollout & Multi-Machine
-
-- **macOS defaults & OS customization** — Revisit `defaults write` settings for new machines: Dock config (auto-hide, icon size, remove default apps), keyboard repeat rate, trackpad settings, Finder preferences, screenshot location, etc. Consider reintroducing `config/macos/` with a `defaults.sh` script that bootstrap or install can call on macOS.
-
 ## Tool Overhauls
 
 - **Neovim config overhaul** — Separate project. Current config is intentionally stubbed out. Full lazy.nvim setup with LSP, treesitter, keymaps, plugins, etc. **Note:** vim-tmux-navigator plugin is installed in tmux and works between tmux panes, but integration with neovim panes requires the neovim counterpart plugin — defer full setup to neovim overhaul.
@@ -24,12 +20,6 @@ Deferred ideas and future improvements.
 
 - **GitHub Actions + pre-commit scaffolding** — Set up lightweight repo automation: config file linting (YAML, TOML, shell via `shellcheck`), a pre-commit hook for basic sanity checks (trailing whitespace, syntax), and a simple GitHub Actions workflow to run the same checks on push/PR. Keep it minimal — no baroque pipelines, just a safety net that catches obvious mistakes before they land.
 
-## Git & Hosting
-
-- **Commit signing across all machines** — Done on main desktop (`commit.gpgsign = true`, `gpg.format = ssh`, `user.signingkey` configured). Still needs to be set up on both laptops (work + personal). Configure `user.signingkey` in each machine's `.gitconfig-user`. Coordinate with the 1Password `op` CLI setup to use 1Password-managed SSH keys for signing.
-- **Codeberg setup** — If/when you want to try Codeberg for personal projects: add SSH key, host entry in SSH config, any git host-level config. Low effort.
-- **GitHub account separation assessment** — Document final decision on single vs separate work/personal GitHub accounts. Current recommendation: stay single-account with `includeIf` path-based identity unless employer requires separation.
-
 # Applications
 
 - **Audit installed applications** — On each primary machine (personal desktop, personal laptop, work laptop), audit `/Applications` and `~/Applications`. Sort everything into the universal/work/personal Brewfile pattern. For apps only available via the Mac App Store, either automate with the `mas` CLI or document the manual install steps.
@@ -41,3 +31,8 @@ Deferred ideas and future improvements.
 ## Performance
 
 - **Shell startup time audit** — Benchmark shell startup time on all primary machines (personal desktop, personal laptop, work laptop) using the RUNBOOK method. Target is under ~500ms warm. One laptop is currently 590–690ms after the mise migration. Profile with `zsh -x` or `zprof` to identify the slowest contributors and optimize if needed. **This should be one of the last TODOs worked from this list** — let other changes land first so the audit captures the final steady-state.
+
+## Someday / Maybe
+
+- **macOS defaults & OS customization** — Revisit `defaults write` settings for new machines: Dock config (auto-hide, icon size, remove default apps), keyboard repeat rate, trackpad settings, Finder preferences, screenshot location, etc. Consider reintroducing `config/macos/` with a `defaults.sh` script that bootstrap or install can call on macOS.
+- **Codeberg setup** — If/when you want to try Codeberg for personal projects: add SSH key, host entry in SSH config, any git host-level config. Low effort.


### PR DESCRIPTION
## Summary

- Enable universal SSH commit signing (`commit.gpgsign = true`, `gpg.format = ssh`) via 1Password-managed keys
- Add `includeIf`-based work/personal git identity switching using `~/code/work/` directory convention
- Bootstrap creates code directories and handles `.gitconfig-work` template on work machines
- Document single-GitHub-account decision, commit signing setup, and directory convention in ARCHITECTURE.md and RUNBOOK.md
- Remove completed "Commit signing across all machines" and "GitHub account separation assessment" from TODO.md

## Test plan

- [x] Git config loads `gpgsign=true`, `includeIf`, and `gpg.format=ssh`
- [x] Personal identity resolves correctly outside `~/code/work/`
- [x] Missing `.gitconfig-work` on personal machines doesn't error
- [x] Commit signing is active (commit succeeds or fails with signing error if placeholder key)
- [x] `.gitconfig-work` is gitignored
- [x] `./install` runs cleanly
- [x] Bootstrap creates `~/code/personal/` on all machines, `~/code/work/` only on work machines
- [x] Bootstrap copies `.gitconfig-work` from example on work machines
- [x] Bootstrap idempotent on re-run
- [x] Work machine: identity switching resolves work email in `~/code/work/` repos
- [x] Work machine: commit signing works with 1Password SSH key

🤖 Generated with [Claude Code](https://claude.com/claude-code)