### PR TITLE
Add tealdeer custom pages and cheat.sh cheatsheet browser

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -139,17 +139,37 @@ After all cleanup work is complete, these must all be true:
 
 ---
 
-## Part B: Task Plan
+## Part B: Task Plan — Shell Utilities: Tealdeer Custom Pages + Cheatsheet Browser
 
-_No active project. This section will be populated when a new project begins._
+### Phase 1: Infrastructure — Tealdeer custom pages directory + Dotbot symlink
 
-<!--
-Template for new projects:
+#### 1.1 — Create `docs/tldr/` directory structure
+**Type:** Claude Code
 
-### Phase N: Phase Name
+Create `docs/tldr/common/` for platform-agnostic custom tealdeer pages.
 
-#### N.1 — Task title
-**Type:** Claude Code | Human | Collaborative
+#### 1.2 — Add Dotbot symlink in `install.config.yaml`
+**Type:** Claude Code
 
-Task description.
--->
+Symlink `docs/tldr` → `~/Library/Application Support/tealdeer/pages`.
+
+### Phase 2: Create `bin/cheat.sh` script
+
+#### 2.1 — Write `bin/cheat.sh`
+**Type:** Claude Code
+
+fzf-powered cheatsheet browser. No args = topic picker with bat preview. With args = cross-file content search with context preview. Graceful fallback without fzf/bat.
+
+### Phase 3: Author tealdeer custom pages
+
+#### 3.1 — Create 5 tldr-format pages in `docs/tldr/common/`
+**Type:** Claude Code
+
+Pages as `*.page.md`: my-shell, my-git, my-tmux, my-fzf, my-vim. Each has 5-8 curated examples from the corresponding cheatsheet.
+
+### Phase 4: Documentation updates
+
+#### 4.1 — Update ARCHITECTURE.md, RUNBOOK.md, TODO.md, SPEC.md
+**Type:** Claude Code
+
+Add docs/tldr to directory tree, add usage sections for tldr and cheat.sh, mark TODO item complete.

--- a/bin/cheat.sh
+++ b/bin/cheat.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# cheat.sh — fzf-powered cheatsheet browser for docs/*.cheatsheet.md
+#
+# Usage:
+#   cheat.sh            Browse cheatsheets via fzf topic picker
+#   cheat.sh <query>    Search across all cheatsheets for a string
+
+set -euo pipefail
+
+# Resolve cheatsheet directory
+if [[ -n "${DOTFILES:-}" ]]; then
+  DOCS_DIR="$DOTFILES/docs"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")")" && pwd)"
+  DOCS_DIR="$(cd "$SCRIPT_DIR/../docs" && pwd)"
+fi
+
+CHEATSHEET_GLOB="$DOCS_DIR/*.cheatsheet.md"
+
+# Check that at least one cheatsheet exists
+shopt -s nullglob
+files=($CHEATSHEET_GLOB)
+shopt -u nullglob
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "No cheatsheets found in $DOCS_DIR" >&2
+  exit 1
+fi
+
+# Viewer: bat if available, else cat
+viewer() {
+  if command -v bat > /dev/null; then
+    bat --language=markdown --style=plain --paging=always "$@"
+  else
+    cat "$@"
+  fi
+}
+
+# Mode 1: no args — topic picker
+if [[ $# -eq 0 ]]; then
+  if command -v fzf > /dev/null; then
+    selected=$(printf '%s\n' "${files[@]}" \
+      | while read -r f; do
+          basename "$f" .cheatsheet.md
+        done \
+      | fzf --prompt="cheatsheet> " \
+            --preview="bat --language=markdown --style=plain --color=always '$DOCS_DIR/{}.cheatsheet.md' 2>/dev/null || cat '$DOCS_DIR/{}.cheatsheet.md'" \
+            --preview-window=right:70%)
+    [[ -n "$selected" ]] && viewer "$DOCS_DIR/$selected.cheatsheet.md"
+  else
+    echo "Available cheatsheets:" >&2
+    for f in "${files[@]}"; do
+      echo "  $(basename "$f" .cheatsheet.md)"
+    done
+    echo "Install fzf for interactive browsing, or pass a topic name as argument." >&2
+  fi
+  exit 0
+fi
+
+# Mode 2: with args — content search
+query="$*"
+if command -v rg > /dev/null; then
+  search_cmd=(rg --line-number --no-heading --color=never "$query" "${files[@]}")
+else
+  search_cmd=(grep -rn "$query" "${files[@]}")
+fi
+
+results=$("${search_cmd[@]}" 2>/dev/null || true)
+if [[ -z "$results" ]]; then
+  echo "No matches for '$query' in cheatsheets." >&2
+  exit 1
+fi
+
+if command -v fzf > /dev/null; then
+  # Strip DOCS_DIR prefix so fzf shows "git.cheatsheet.md:105:..." not the full path
+  export DOCS_DIR
+  selected=$(echo "$results" \
+    | sed "s|^${DOCS_DIR}/||" \
+    | fzf --prompt="match> " \
+          --delimiter=: \
+          --preview='
+            line=$(echo {} | cut -d: -f2)
+            name=$(echo {} | cut -d: -f1)
+            file="$DOCS_DIR/$name"
+            start=$((line > 5 ? line - 5 : 1))
+            end=$((line + 20))
+            bat --language=markdown --style=plain --color=always --highlight-line "$line" --line-range "$start:$end" "$file" 2>/dev/null || sed -n "${start},${end}p" "$file"
+          ' \
+          --preview-window=right:70%)
+  if [[ -n "$selected" ]]; then
+    file="$DOCS_DIR/$(echo "$selected" | cut -d: -f1)"
+    line=$(echo "$selected" | cut -d: -f2)
+    if command -v bat > /dev/null; then
+      bat --language=markdown --style=plain --paging=always --highlight-line "$line" "$file"
+    else
+      cat "$file"
+    fi
+  fi
+else
+  echo "$results"
+fi

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,6 +32,9 @@ dotfiles/
 │   ├── ARCHITECTURE.md       # This file — design reference (not consumed by tooling)
 │   ├── RUNBOOK.md            # Detailed usage and maintenance reference
 │   ├── TODO.md               # Future ideas and deferred work
+│   ├── *.cheatsheet.md       # Tool cheatsheets (fzf, tmux, git, shell, vim, kubernetes)
+│   └── tldr/                 # Custom tealdeer pages (symlinked to ~/Library/Application Support/tealdeer/pages)
+│       └── my-*.page.md     # Custom pages: my-git, my-shell, my-tmux, my-fzf, my-vim
 ├── zsh/
 │   ├── zshrc.zsh             # Entrypoint (symlinked to ~/.zshrc)
 │   ├── lib/                  # Modular zsh config files (auto-sourced alphabetically)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -296,7 +296,7 @@ dotfiles/
 ├── install                   # Dotbot bootstrap script
 ├── install.config.yaml       # Dotbot symlink + shell command config
 ├── bin/                      # Scripts symlinked to ~/bin (includes bootstrap wizard)
-├── docs/                     # Cheatsheets (fzf, tmux, git, shell, kubernetes)
+├── docs/                     # Cheatsheets, tldr custom pages, architecture docs
 ├── env/
 │   ├── work.zsh              # Sourced when ~/.work exists
 │   ├── personal.zsh          # Sourced when ~/.personal exists
@@ -458,6 +458,47 @@ Drop a file in `zsh/lib/yourfile.zsh` — it will be sourced automatically next 
 ### New bin script
 
 Drop it in `bin/` — Dotbot glob-symlinks the whole directory to `~/bin`, so it's in PATH after `./install`.
+
+### New tealdeer custom page
+
+Create `docs/tldr/my-<topic>.page.md` following the [tldr page format](https://github.com/tldr-pages/tldr/blob/main/contributing-guides/style-guide.md):
+- `# title` header
+- `> one-line description`
+- `- comment` then `` `command` `` pairs (5-8 examples)
+- Each code block must contain exactly one command (no `cmd1` / `cmd2` splits)
+
+After `./install`, the page is available via `tldr my-<topic>`. Existing pages: my-shell, my-git, my-tmux, my-fzf, my-vim.
+
+---
+
+## Cheatsheet Tools
+
+### `tldr my-<topic>` — Quick reference (tealdeer custom pages)
+
+Curated "greatest hits" from each cheatsheet, accessible via tealdeer:
+
+```sh
+tldr my-git       # top git aliases
+tldr my-shell     # top shell aliases
+tldr my-tmux      # tmux keybindings
+tldr my-fzf       # fzf bindings and completion
+tldr my-vim       # vim keybindings
+tldr --list | grep my-   # list all custom pages
+```
+
+Pages live in `docs/tldr/` as `*.page.md` files and are symlinked to tealdeer's custom pages directory by dotbot.
+
+### `cheat.sh` — Full cheatsheet browser
+
+Browse or search the full `docs/*.cheatsheet.md` files with fzf + bat:
+
+```sh
+cheat.sh              # fzf topic picker → bat render
+cheat.sh grep         # search across all cheatsheets for "grep"
+cheat.sh stash        # find stash-related entries across all files
+```
+
+**Dependencies:** fzf, bat (both in Brewfile.universal). Falls back gracefully: without fzf lists topics; without bat uses cat.
 
 ---
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -26,7 +26,7 @@ Deferred ideas and future improvements.
 
 ## Shell Utilities
 
-- **Custom tealdeer pages** — Investigate whether tealdeer supports custom/local page overrides for documenting personal aliases and cheatsheet entries alongside community pages.
+- ~~**Custom tealdeer pages**~~ — Done. Custom pages in `docs/tldr/common/my-*.md`, symlinked via dotbot. `cheat.sh` provides fzf-powered browsing of full cheatsheets.
 
 ## Performance
 

--- a/docs/tldr/my-fzf.page.md
+++ b/docs/tldr/my-fzf.page.md
@@ -1,0 +1,31 @@
+# my-fzf
+
+> fzf key bindings and completion patterns from the dotfiles repo.
+
+- Find files/directories and insert into command prompt:
+
+`Ctrl+T`
+
+- Fuzzy search shell history:
+
+`Ctrl+R`
+
+- Fuzzy cd into a subdirectory (Alt+C on Linux, ç on macOS):
+
+`Alt+C`
+
+- Fuzzy file completion for any command:
+
+`vim **<TAB>`
+
+- Fuzzy directory-only completion:
+
+`cd **<TAB>`
+
+- Fuzzy SSH hostname completion:
+
+`ssh **<TAB>`
+
+- Open fzf with bat syntax-highlighted preview:
+
+`preview`

--- a/docs/tldr/my-git.page.md
+++ b/docs/tldr/my-git.page.md
@@ -1,0 +1,39 @@
+# my-git
+
+> Personal git aliases from the dotfiles repo. Forgit overrides (ga, glo, grh, gcb, gco, gss, grb) provide interactive fzf versions.
+
+- Show short status with branch info:
+
+`gsb`
+
+- Stage all files and commit with a message:
+
+`gaa && gcmsg "{{message}}"`
+
+- Push current branch and set upstream:
+
+`gpsup`
+
+- Pull with rebase and autostash:
+
+`gupa`
+
+- Interactive log browser (forgit):
+
+`glo`
+
+- Stash current changes:
+
+`gsta`
+
+- Pop the latest stash:
+
+`gstp`
+
+- Checkout the default branch (auto-detects main/master):
+
+`gcm`
+
+- Open lazygit TUI:
+
+`lg`

--- a/docs/tldr/my-shell.page.md
+++ b/docs/tldr/my-shell.page.md
@@ -1,0 +1,39 @@
+# my-shell
+
+> Personal shell aliases and utilities from the dotfiles repo.
+
+- List files with details, git status, and icons:
+
+`l`
+
+- List files with full timestamps, group, and git repo status:
+
+`ll`
+
+- Tree view, 3 levels deep:
+
+`lt`
+
+- Jump to a frecent directory with zoxide:
+
+`z {{query}}`
+
+- Full Homebrew update cycle (update, outdated, upgrade, doctor, cleanup):
+
+`bubu`
+
+- Show external IP and local network addresses:
+
+`ip`
+
+- Show current weather for Atlanta:
+
+`weather`
+
+- Reload shell config:
+
+`reload!`
+
+- Fuzzy file finder with bat syntax-highlighted preview:
+
+`preview`

--- a/docs/tldr/my-tmux.page.md
+++ b/docs/tldr/my-tmux.page.md
@@ -1,0 +1,47 @@
+# my-tmux
+
+> Personal tmux keybindings (prefix is C-a) from the dotfiles repo.
+
+- New window:
+
+`prefix c`
+
+- Kill current pane:
+
+`prefix x`
+
+- Split horizontally (new pane right):
+
+`prefix \`
+
+- Split vertically (new pane below):
+
+`prefix -`
+
+- Navigate panes (vim-style):
+
+`prefix h/j/k/l`
+
+- Zoom/unzoom current pane:
+
+`prefix +`
+
+- Enter copy mode:
+
+`prefix [`
+
+- In copy mode, select with v then yank with y:
+
+`v → y`
+
+- SSH to host via fzf fuzzy picker:
+
+`prefix S`
+
+- Toggle pane synchronization (broadcast input to all panes):
+
+`prefix e`
+
+- Reload tmux config:
+
+`prefix r`

--- a/docs/tldr/my-vim.page.md
+++ b/docs/tldr/my-vim.page.md
@@ -1,0 +1,55 @@
+# my-vim
+
+> Personal vim/vimrc keybindings from the dotfiles repo (minimal config, no plugins).
+
+- Exit insert mode:
+
+`jj`
+
+- Navigate between splits:
+
+`Ctrl-H/J/K/L`
+
+- Open a vertical split:
+
+`Ctrl-\`
+
+- Open file in new tab:
+
+`tt`
+
+- Next tab:
+
+`tj`
+
+- Previous tab:
+
+`tk`
+
+- Jump to first tab:
+
+`th`
+
+- Jump to last tab:
+
+`tl`
+
+- Insert shell command output below cursor:
+
+`:r !{{command}}`
+
+- Toggle fold under cursor:
+
+`za`
+
+- Open all folds:
+
+`zR`
+
+- Close all folds:
+
+`zM`
+
+- Save file as sudo:
+
+`W!!`

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -97,6 +97,11 @@
       path: config/launchagents/com.dnall.dark-notify.plist
       force: true
 
+    ~/Library/Application Support/tealdeer/pages:
+      path: docs/tldr
+      force: true
+      create: true
+
     ~/bin:
       glob: true
       path: bin/*


### PR DESCRIPTION
## Summary

- **5 custom tealdeer pages** (`my-shell`, `my-git`, `my-tmux`, `my-fzf`, `my-vim`) — curated "greatest hits" from each cheatsheet, accessible via `tldr my-<topic>`
- **`bin/cheat.sh`** — fzf-powered browser over `docs/*.cheatsheet.md` with two modes: no-args topic picker with bat preview, or `cheat.sh <query>` for cross-file content search
- **Dotbot symlink** for tealdeer custom pages directory
- **Docs updated** — ARCHITECTURE.md, RUNBOOK.md, TODO.md, SPEC.md

## Test plan

- [x] `./install` runs clean, creates tealdeer pages symlink
- [x] `tldr my-git`, `my-shell`, `my-tmux`, `my-fzf`, `my-vim` all render correctly
- [x] `tldr --list | grep my-` shows all 5 custom pages
- [x] `cheat.sh` (no args) — fzf topic picker with bat preview
- [x] `cheat.sh stash` — cross-file search with preview and highlight
- [x] `cheat.sh split` — matches across multiple cheatsheet files
- [x] `cheat.sh xyznonexistent` — prints "No matches" and exits
- [x] `which cheat.sh` in new shell resolves to `~/bin/cheat.sh`
- [x] Shell startup unaffected (no new sourced files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)