### PR TITLE
Add pre-commit hooks and GitHub Actions CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install zsh
+        run: sudo apt-get update && sudo apt-get install -y zsh
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,13 @@
+name: Lint
+on:
+  pull_request:
+    branches: [main]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+        files: ^bin/
+        exclude: ^bin/(tunes\.js|brew-repair)$
+
+  - repo: local
+    hooks:
+      - id: zsh-syntax-check
+        name: zsh syntax check
+        language: system
+        entry: zsh -n
+        files: '\.zsh$'

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+shell=bash

--- a/SPEC.md
+++ b/SPEC.md
@@ -139,37 +139,26 @@ After all cleanup work is complete, these must all be true:
 
 ---
 
-## Part B: Task Plan — Shell Utilities: Tealdeer Custom Pages + Cheatsheet Browser
+## Part B: Task Plan — GitHub Actions + Pre-commit Scaffolding
 
-### Phase 1: Infrastructure — Tealdeer custom pages directory + Dotbot symlink
+### Phase 1: Pre-commit auto-fix cleanup
+Run trailing-whitespace and end-of-file-fixer on all files. Commit fixes separately.
 
-#### 1.1 — Create `docs/tldr/` directory structure
-**Type:** Claude Code
+### Phase 2: Create new files
+- `.shellcheckrc` — `shell=bash` default
+- `.pre-commit-config.yaml` — pre-commit-hooks, shellcheck-py, local zsh-syntax-check
+- `.github/workflows/lint.yml` — PR-only CI via `pre-commit/action`
 
-Create `docs/tldr/common/` for platform-agnostic custom tealdeer pages.
+### Phase 3: Modify existing files
+- `packages/Brewfile.universal` — add `pre-commit`
+- `packages/Brewfile.work` — remove quarantined `pre-commit`
+- `install.config.yaml` — add guarded `pre-commit install` shell command
 
-#### 1.2 — Add Dotbot symlink in `install.config.yaml`
-**Type:** Claude Code
+### Phase 4: Fix shellcheck findings
+Run shellcheck on `bin/` scripts and fix or inline-suppress findings.
 
-Symlink `docs/tldr` → `~/Library/Application Support/tealdeer/pages`.
-
-### Phase 2: Create `bin/cheat.sh` script
-
-#### 2.1 — Write `bin/cheat.sh`
-**Type:** Claude Code
-
-fzf-powered cheatsheet browser. No args = topic picker with bat preview. With args = cross-file content search with context preview. Graceful fallback without fzf/bat.
-
-### Phase 3: Author tealdeer custom pages
-
-#### 3.1 — Create 5 tldr-format pages in `docs/tldr/common/`
-**Type:** Claude Code
-
-Pages as `*.page.md`: my-shell, my-git, my-tmux, my-fzf, my-vim. Each has 5-8 curated examples from the corresponding cheatsheet.
-
-### Phase 4: Documentation updates
-
-#### 4.1 — Update ARCHITECTURE.md, RUNBOOK.md, TODO.md, SPEC.md
-**Type:** Claude Code
-
-Add docs/tldr to directory tree, add usage sections for tldr and cheat.sh, mark TODO item complete.
+### Phase 5: Documentation updates
+- `docs/ARCHITECTURE.md` — directory tree + section 3.9
+- `docs/RUNBOOK.md` — pre-commit usage section
+- `docs/TODO.md` — strikethrough CI item
+- `SPEC.md` — replace Part B with this plan

--- a/bin/cheat.sh
+++ b/bin/cheat.sh
@@ -18,9 +18,7 @@ fi
 CHEATSHEET_GLOB="$DOCS_DIR/*.cheatsheet.md"
 
 # Check that at least one cheatsheet exists
-shopt -s nullglob
-files=($CHEATSHEET_GLOB)
-shopt -u nullglob
+mapfile -t files < <(compgen -G "$CHEATSHEET_GLOB")
 if [[ ${#files[@]} -eq 0 ]]; then
   echo "No cheatsheets found in $DOCS_DIR" >&2
   exit 1
@@ -77,14 +75,14 @@ if command -v fzf > /dev/null; then
     | sed "s|^${DOCS_DIR}/||" \
     | fzf --prompt="match> " \
           --delimiter=: \
-          --preview='
-            line=$(echo {} | cut -d: -f2)
-            name=$(echo {} | cut -d: -f1)
-            file="$DOCS_DIR/$name"
-            start=$((line > 5 ? line - 5 : 1))
-            end=$((line + 20))
-            bat --language=markdown --style=plain --color=always --highlight-line "$line" --line-range "$start:$end" "$file" 2>/dev/null || sed -n "${start},${end}p" "$file"
-          ' \
+          --preview="
+            line=\$(echo {} | cut -d: -f2)
+            name=\$(echo {} | cut -d: -f1)
+            file=\"$DOCS_DIR/\$name\"
+            start=\$((line > 5 ? line - 5 : 1))
+            end=\$((line + 20))
+            bat --language=markdown --style=plain --color=always --highlight-line \"\$line\" --line-range \"\$start:\$end\" \"\$file\" 2>/dev/null || sed -n \"\${start},\${end}p\" \"\$file\"
+          " \
           --preview-window=right:70%)
   if [[ -n "$selected" ]]; then
     file="$DOCS_DIR/$(echo "$selected" | cut -d: -f1)"

--- a/config/bash/bashrc
+++ b/config/bash/bashrc
@@ -100,7 +100,7 @@ complete -F autoCompleteHostname ssr
 function dusk() {
   du -sk "$@" | sort -n | while read size fname;
     do for unit in k M G T P E Z Y;
-      do if [ $size -lt 1024 ]; 
+      do if [ $size -lt 1024 ];
         then echo -e "${size}${unit}\t${fname}";
         break;
       fi;
@@ -112,7 +112,7 @@ function dusk() {
 function duck() {
   du -ck "$@" | sort -n | while read size fname;
     do for unit in k M G T P E Z Y;
-      do if [ $size -lt 1024 ]; 
+      do if [ $size -lt 1024 ];
         then echo -e "${size}${unit}\t${fname}";
         break;
       fi;

--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -38,4 +38,3 @@ github = 'zsh-users/zsh-history-substring-search'
 
 [plugins.alias-tips]
 github = "djui/alias-tips"
-

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -149,7 +149,7 @@ dotfiles/
 
 - **Pre-commit** (`.pre-commit-config.yaml`) runs all lint checks both locally and in CI. Single source of truth — CI calls `pre-commit run --all-files` via `pre-commit/action`.
 - **Hooks:** trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files, shellcheck (scoped to `bin/`, excluding `tunes.js` and `brew-repair`), zsh syntax check (`zsh -n` on all `.zsh` files).
-- **GitHub Actions** (`.github/workflows/lint.yml`) runs on PRs targeting `main`. Uses `ubuntu-latest` (zsh pre-installed).
+- **GitHub Actions** (`.github/workflows/lint.yml`) runs on PRs targeting `main`. Uses `ubuntu-latest` (installs zsh via apt).
 - **ShellCheck** (`.shellcheckrc`) defaults to `shell=bash`. No global suppressions — fix or inline-suppress case-by-case.
 - **Dotbot integration:** `./install` runs `pre-commit install` (guarded with `command -v`) to set up local git hooks automatically.
 - **Brewfile:** `pre-commit` is in `Brewfile.universal`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,7 +21,12 @@ This repo consolidates shell and tool configurations into a single, idempotent d
 ```text
 dotfiles/
 ├── .git/
+├── .github/
+│   └── workflows/
+│       └── lint.yml          # GitHub Actions CI (pre-commit on PRs)
 ├── .gitignore
+├── .pre-commit-config.yaml   # Pre-commit hook definitions
+├── .shellcheckrc             # ShellCheck defaults (shell=bash)
 ├── README.md                 # Quick-start guide
 ├── SPEC.md                   # Current project task plan
 ├── dotbot/                   # Git submodule
@@ -139,6 +144,15 @@ dotfiles/
 - **Identity switching:** `config/git/config` uses `[includeIf "gitdir:~/code/work/"]` to load `.gitconfig-work` (work name, email, signingkey). All other repos use the default `.gitconfig-user` (personal identity). Directory convention: `~/code/work/` for work repos, `~/code/personal/` for personal repos.
 - **Commit signing:** `commit.gpgsign = true` is shared config (in `config/git/config`). `user.signingkey` is per-machine, set in `.gitconfig-user` and `.gitconfig-work`. `gpg.format = ssh` — all machines target 1Password-managed SSH keys for signing.
 - **`allowed_signers`:** Intentionally skipped. GitHub handles signature verification via uploaded signing keys — local verification isn't needed for this workflow.
+
+### 3.9 CI and Linting
+
+- **Pre-commit** (`.pre-commit-config.yaml`) runs all lint checks both locally and in CI. Single source of truth — CI calls `pre-commit run --all-files` via `pre-commit/action`.
+- **Hooks:** trailing-whitespace, end-of-file-fixer, check-yaml, check-added-large-files, shellcheck (scoped to `bin/`, excluding `tunes.js` and `brew-repair`), zsh syntax check (`zsh -n` on all `.zsh` files).
+- **GitHub Actions** (`.github/workflows/lint.yml`) runs on PRs targeting `main`. Uses `ubuntu-latest` (zsh pre-installed).
+- **ShellCheck** (`.shellcheckrc`) defaults to `shell=bash`. No global suppressions — fix or inline-suppress case-by-case.
+- **Dotbot integration:** `./install` runs `pre-commit install` (guarded with `command -v`) to set up local git hooks automatically.
+- **Brewfile:** `pre-commit` is in `Brewfile.universal`.
 
 ---
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -423,6 +423,39 @@ Then run `mise install` in that directory. mise activates the correct versions a
 sheldon lock --update
 ```
 
+### Pre-commit hooks
+
+Run all checks (same as CI):
+
+```sh
+pre-commit run --all-files
+```
+
+Run a specific hook:
+
+```sh
+pre-commit run shellcheck --all-files
+pre-commit run trailing-whitespace --all-files
+```
+
+Update hook versions:
+
+```sh
+pre-commit autoupdate
+```
+
+Re-install hooks (after clone or if `.git/hooks/pre-commit` is missing):
+
+```sh
+pre-commit install
+```
+
+Bypass hooks for a single commit (use sparingly):
+
+```sh
+git commit --no-verify -m "message"
+```
+
 ### Benchmark shell startup time
 
 ```sh

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -18,7 +18,7 @@ Deferred ideas and future improvements.
 
 ## CI / Repo Health
 
-- **GitHub Actions + pre-commit scaffolding** — Set up lightweight repo automation: config file linting (YAML, TOML, shell via `shellcheck`), a pre-commit hook for basic sanity checks (trailing whitespace, syntax), and a simple GitHub Actions workflow to run the same checks on push/PR. Keep it minimal — no baroque pipelines, just a safety net that catches obvious mistakes before they land.
+- ~~**GitHub Actions + pre-commit scaffolding**~~ — Done. Pre-commit hooks (shellcheck, zsh syntax, YAML, whitespace/EOF) with GitHub Actions CI on PRs. `pre-commit install` wired into dotbot.
 
 # Applications
 

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -128,6 +128,9 @@
      description: Build bat theme cache
      stdout: true
     -
+     command: 'command -v pre-commit > /dev/null && [ -d .git ] && pre-commit install || true'
+     description: Install pre-commit git hooks
+    -
      command: |
        if [[ "$(uname)" == "Darwin" ]] && command -v dark-notify > /dev/null; then
          launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.dnall.dark-notify.plist 2>/dev/null || true

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -69,6 +69,7 @@ brew "vim"
 
 # Dev tools
 brew "jq"             # JSON processor
+brew "pre-commit"     # git hooks framework
 brew "yq"             # YAML processor
 brew "wget"
 brew "httpie"

--- a/packages/Brewfile.work
+++ b/packages/Brewfile.work
@@ -35,7 +35,6 @@ cask "lens"
 # brew "gnupg"                 # 20260313
 # brew "libpq", link: true     # 20260313
 # brew "libsndfile"            # 20260313
-# brew "pre-commit"            # git hooks framework — 20260315
 # brew "puma/puma/puma-dev"    # 20260313
 # brew "rabbitmq"              # message broker — 20260315
 # brew "redis"                 # in-memory database — 20260315

--- a/zsh/lib/local.zsh.template
+++ b/zsh/lib/local.zsh.template
@@ -1,4 +1,3 @@
 # Add some shortcuts to projects you often work on
 # Example:
 # dotfiles=/Users/dnall/.dotfiles
-

--- a/zsh/zfunctions/clipboard
+++ b/zsh/zfunctions/clipboard
@@ -41,7 +41,7 @@ function clipcopy() {
       fi
     elif (( $+commands[xsel] )); then
       if [[ -z $file ]]; then
-        xsel --clipboard --input 
+        xsel --clipboard --input
       else
         cat "$file" | xsel --clipboard --input
       fi

--- a/zsh/zfunctions/color_list
+++ b/zsh/zfunctions/color_list
@@ -1,8 +1,8 @@
 function color_list() {
-  for i in {0..255}; do 
-    printf "\x1b[38;5;${i}mcolor%-5i\x1b[0m" $i ; 
-    if ! (( ($i + 1 ) % 8 )); 
-      then echo ; 
-    fi ; 
+  for i in {0..255}; do
+    printf "\x1b[38;5;${i}mcolor%-5i\x1b[0m" $i ;
+    if ! (( ($i + 1 ) % 8 ));
+      then echo ;
+    fi ;
   done
 }

--- a/zsh/zshrc.zsh
+++ b/zsh/zshrc.zsh
@@ -104,4 +104,3 @@ fi
 
 if [[ -f "${HOME}/.env.local" ]]; then source "${HOME}/.env.local"; fi
 if [[ -f "${HOME}/.secrets.local" ]]; then source "${HOME}/.secrets.local"; fi
-


### PR DESCRIPTION
## Summary
- Add pre-commit framework with shellcheck, zsh syntax check, YAML validation, whitespace/EOF fixers, and large file check
- Add GitHub Actions workflow that runs `pre-commit run --all-files` on PRs targeting main
- Wire `pre-commit install` into dotbot (guarded), add `pre-commit` to Brewfile.universal, remove quarantined entry from Brewfile.work
- Fix existing trailing whitespace and missing EOF newlines (6 files)
- Fix shellcheck findings in `bin/cheat.sh` (SC2206, SC2016)

## Test plan
- [x] `pre-commit run --all-files` — all 6 hooks pass
- [x] `./install` completes without errors (pre-commit install step works)
- [x] GH Actions workflow triggers and passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)