### PR TITLE
✨ Neovim config overhaul — lazy.nvim + LSP + NordicPine

### DIFF
--- a/bin/theme-switch
+++ b/bin/theme-switch
@@ -39,6 +39,13 @@ if [[ -f "$btop_conf" ]]; then
   fi
 fi
 
+# Neovim — send ThemeSwitch command to all running instances
+for sock in /tmp/nvim-"$(whoami)"-*.sock; do
+  [[ -S "$sock" ]] || continue
+  nvim_bin="$(command -v nvim 2>/dev/null || echo /opt/homebrew/bin/nvim)"
+  "$nvim_bin" --server "$sock" --remote-send "<Cmd>ThemeSwitch $mode<CR>" 2>/dev/null || true
+done
+
 # starship — switch palette (takes effect on next prompt)
 starship_conf="$(_resolve "$HOME/.config/starship.toml")"
 if [[ -f "$starship_conf" ]]; then

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -1,0 +1,35 @@
+-- init.lua — Neovim entrypoint
+
+-- Set leader before anything else
+vim.g.mapleader = " "
+vim.g.maplocalleader = " "
+
+-- Bootstrap lazy.nvim
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.uv.fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable",
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+-- Load config modules
+require("config.options")
+require("config.keymaps")
+require("config.autocmds")
+
+-- Setup plugins (auto-discovers lua/plugins/*.lua)
+require("lazy").setup("plugins")
+
+-- Appearance (after plugins load)
+require("config.appearance").setup()
+
+-- Named server socket for theme-switch remote commands
+local user = vim.fn.expand("$USER")
+local pid = vim.fn.getpid()
+vim.fn.serverstart("/tmp/nvim-" .. user .. "-" .. pid .. ".sock")

--- a/config/nvim/lazy-lock.json
+++ b/config/nvim/lazy-lock.json
@@ -1,0 +1,23 @@
+{
+  "blink.cmp": { "branch": "main", "commit": "451168851e8e2466bc97ee3e026c3dcb9141ce07" },
+  "conform.nvim": { "branch": "master", "commit": "086a40dc7ed8242c03be9f47fbcee68699cc2395" },
+  "gitsigns.nvim": { "branch": "main", "commit": "7c4faa3540d0781a28588cafbd4dd187a28ac6e3" },
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "lualine.nvim": { "branch": "master", "commit": "47f91c416daef12db467145e16bed5bbfe00add8" },
+  "mason-lspconfig.nvim": { "branch": "main", "commit": "a979821a975897b88493843301950c456a725982" },
+  "mason.nvim": { "branch": "main", "commit": "44d1e90e1f66e077268191e3ee9d2ac97cc18e65" },
+  "mini.surround": { "branch": "main", "commit": "88c52297ed3e69ecf9f8652837888ecc727a28ee" },
+  "neo-tree.nvim": { "branch": "v3.x", "commit": "9d6826582a3e8c84787bd7355df22a2812a1ad59" },
+  "nui.nvim": { "branch": "main", "commit": "de740991c12411b663994b2860f1a4fd0937c130" },
+  "nvim-autopairs": { "branch": "master", "commit": "59bce2eef357189c3305e25bc6dd2d138c1683f5" },
+  "nvim-lspconfig": { "branch": "master", "commit": "841c6d4139aedb8a3f2baf30cef5327371385b93" },
+  "nvim-treesitter": { "branch": "main", "commit": "877f724846f2202a16e311bd19efb954bd1c430e" },
+  "nvim-web-devicons": { "branch": "master", "commit": "d7462543c9e366c0d196c7f67a945eaaf5d99414" },
+  "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
+  "rose-pine": { "branch": "main", "commit": "cf2a288696b03d0934da713d66c6d71557b5c997" },
+  "telescope-fzf-native.nvim": { "branch": "main", "commit": "6fea601bd2b694c6f2ae08a6c6fab14930c60e2c" },
+  "telescope.nvim": { "branch": "master", "commit": "5255aa27c422de944791318024167ad5d40aad20" },
+  "vim-fugitive": { "branch": "master", "commit": "3b753cf8c6a4dcde6edee8827d464ba9b8c4a6f0" },
+  "vim-tmux-navigator": { "branch": "master", "commit": "e41c431a0c7b7388ae7ba341f01a0d217eb3a432" },
+  "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
+}

--- a/config/nvim/lua/config/appearance.lua
+++ b/config/nvim/lua/config/appearance.lua
@@ -1,0 +1,111 @@
+-- appearance.lua — state file reader, ThemeSwitch command, Rose Pine variant control
+
+local M = {}
+
+-- NordicPine highlight overrides for dark mode
+-- Mapped from docs/color-palettes.md onto Rose Pine's highlight groups
+local nordicpine_overrides = {
+  -- Base UI
+  Normal = { fg = "#c6e0df", bg = "#0f111a" },
+  NormalFloat = { fg = "#c6e0df", bg = "#1c2030" },
+  NormalNC = { fg = "#c6e0df", bg = "#0f111a" },
+  CursorLine = { bg = "#232a3b" },
+  CursorLineNr = { fg = "#c6e0df", bold = true },
+  LineNr = { fg = "#555e7a" },
+  Visual = { bg = "#232a3b" },
+  Search = { fg = "#0f111a", bg = "#e6cc6f" },
+  CurSearch = { fg = "#0f111a", bg = "#ddbc44" },
+  IncSearch = { link = "CurSearch" },
+  Pmenu = { fg = "#c6e0df", bg = "#1c2030" },
+  PmenuSel = { fg = "#e4f5f4", bg = "#232a3b" },
+  PmenuSbar = { bg = "#1c2030" },
+  PmenuThumb = { bg = "#555e7a" },
+  FloatBorder = { fg = "#343b51" },
+  WinSeparator = { fg = "#343b51" },
+  StatusLine = { fg = "#c6e0df", bg = "#1c2030" },
+  StatusLineNC = { fg = "#555e7a", bg = "#1c2030" },
+  Title = { fg = "#6ab4c2", bold = true },
+
+  -- Syntax
+  Comment = { fg = "#343b51", italic = true },
+  String = { fg = "#e6cc6f" },
+  Constant = { fg = "#e6cc6f" },
+  Number = { fg = "#e6cc6f" },
+  Boolean = { fg = "#cca2c0" },
+  Function = { fg = "#38c9a7" },
+  Keyword = { fg = "#087fab", bold = true },
+  Statement = { fg = "#087fab", bold = true },
+  Identifier = { fg = "#c6e0df" },
+  Type = { fg = "#6ab4c2" },
+  Special = { fg = "#6ab4c2" },
+  SpecialComment = { fg = "#cca2c0" },
+  Operator = { fg = "#c6e0df" },
+  ["@punctuation"] = { fg = "#555e7a" },
+
+  -- Diagnostics
+  DiagnosticError = { fg = "#e16c58" },
+  DiagnosticWarn = { fg = "#ddbc44" },
+  DiagnosticInfo = { fg = "#6ab4c2" },
+  DiagnosticHint = { fg = "#cca2c0" },
+  DiagnosticOk = { fg = "#26a98b" },
+
+  -- Git signs
+  GitSignsAdd = { fg = "#26a98b", bg = "NONE" },
+  GitSignsChange = { fg = "#cca2c0", bg = "NONE" },
+  GitSignsDelete = { fg = "#e16c58", bg = "NONE" },
+  DiffAdd = { bg = "#26a98b", blend = 15 },
+  DiffChange = { bg = "#cca2c0", blend = 15 },
+  DiffDelete = { bg = "#e16c58", blend = 15 },
+}
+
+function M.apply(mode)
+  -- Reset rose-pine config to defaults before each apply, because
+  -- setup() deep-merges into existing state and won't clear old overrides
+  require("rose-pine.config").options = vim.deepcopy(require("rose-pine.config").options)
+  require("rose-pine.config").options.highlight_groups = {}
+
+  if mode == "light" then
+    vim.o.background = "light"
+    require("rose-pine").setup({
+      variant = "dawn",
+      dark_variant = "moon",
+    })
+  else
+    vim.o.background = "dark"
+    require("rose-pine").setup({
+      variant = "moon",
+      dark_variant = "moon",
+      highlight_groups = nordicpine_overrides,
+    })
+  end
+  vim.cmd("colorscheme rose-pine")
+end
+
+function M.setup()
+  -- Read state file
+  local state_file = vim.fn.expand("~/.local/state/appearance")
+  local mode = "dark"
+  local f = io.open(state_file, "r")
+  if f then
+    local content = f:read("*l")
+    f:close()
+    if content and content:match("light") then
+      mode = "light"
+    end
+  end
+
+  M.apply(mode)
+
+  -- User command for live switching
+  vim.api.nvim_create_user_command("ThemeSwitch", function(opts)
+    M.apply(opts.args)
+  end, {
+    nargs = 1,
+    complete = function()
+      return { "dark", "light" }
+    end,
+    desc = "Switch between dark and light themes",
+  })
+end
+
+return M

--- a/config/nvim/lua/config/autocmds.lua
+++ b/config/nvim/lua/config/autocmds.lua
@@ -1,0 +1,54 @@
+-- autocmds.lua — autocommands
+
+local augroup = vim.api.nvim_create_augroup
+local autocmd = vim.api.nvim_create_autocmd
+
+-- Highlight on yank
+autocmd("TextYankPost", {
+  group = augroup("YankHighlight", { clear = true }),
+  callback = function()
+    vim.highlight.on_yank()
+  end,
+})
+
+-- Restore cursor position on file open
+autocmd("BufReadPost", {
+  group = augroup("RestoreCursor", { clear = true }),
+  callback = function()
+    local mark = vim.api.nvim_buf_get_mark(0, '"')
+    local lcount = vim.api.nvim_buf_line_count(0)
+    if mark[1] > 0 and mark[1] <= lcount then
+      pcall(vim.api.nvim_win_set_cursor, 0, mark)
+    end
+  end,
+})
+
+-- Filetype overrides: markdown/text get wrap
+autocmd("FileType", {
+  group = augroup("WrapFiletypes", { clear = true }),
+  pattern = { "markdown", "text" },
+  callback = function()
+    vim.opt_local.wrap = true
+    vim.opt_local.linebreak = true
+  end,
+})
+
+-- Auto-reload on focus
+autocmd({ "FocusGained", "BufEnter" }, {
+  group = augroup("AutoReload", { clear = true }),
+  command = "checktime",
+})
+
+-- Resize splits on VimResized
+autocmd("VimResized", {
+  group = augroup("ResizeSplits", { clear = true }),
+  command = "tabdo wincmd =",
+})
+
+-- Diagnostic float on CursorHold
+autocmd("CursorHold", {
+  group = augroup("DiagnosticFloat", { clear = true }),
+  callback = function()
+    vim.diagnostic.open_float(nil, { focusable = false })
+  end,
+})

--- a/config/nvim/lua/config/keymaps.lua
+++ b/config/nvim/lua/config/keymaps.lua
@@ -1,0 +1,31 @@
+-- keymaps.lua — non-plugin keymaps
+
+local map = vim.keymap.set
+
+-- jj to escape
+map("i", "jj", "<Esc>", { desc = "Escape" })
+
+-- Clear search highlight
+map("n", "<Leader>/", "<Cmd>nohlsearch<CR>", { desc = "Clear search" })
+
+-- Splits
+map("n", "<Leader>sv", "<Cmd>vsplit<CR>", { desc = "Vertical split" })
+map("n", "<Leader>sh", "<Cmd>split<CR>", { desc = "Horizontal split" })
+
+-- Buffer navigation
+map("n", "<S-h>", "<Cmd>bprevious<CR>", { desc = "Previous buffer" })
+map("n", "<S-l>", "<Cmd>bnext<CR>", { desc = "Next buffer" })
+map("n", "<Leader>q", "<Cmd>bdelete<CR>", { desc = "Close buffer" })
+
+-- Better search centering
+map("n", "n", "nzzzv", { desc = "Next search result (centered)" })
+map("n", "N", "Nzzzv", { desc = "Previous search result (centered)" })
+
+-- Move lines in visual mode
+map("v", "J", ":m '>+1<CR>gv=gv", { desc = "Move line down", silent = true })
+map("v", "K", ":m '<-2<CR>gv=gv", { desc = "Move line up", silent = true })
+
+-- Diagnostics
+map("n", "<Leader>cd", vim.diagnostic.open_float, { desc = "Diagnostic float" })
+
+-- NOTE: <C-h/j/k/l> are NOT mapped here — vim-tmux-navigator owns these

--- a/config/nvim/lua/config/options.lua
+++ b/config/nvim/lua/config/options.lua
@@ -1,0 +1,57 @@
+-- options.lua — vim.opt settings (carried forward from vimrc)
+
+local opt = vim.opt
+
+-- Formatting
+opt.tabstop = 2
+opt.shiftwidth = 2
+opt.softtabstop = 2
+opt.expandtab = true
+opt.smarttab = true
+opt.autoindent = true
+
+-- Search
+opt.hlsearch = true
+opt.incsearch = true
+opt.ignorecase = true
+opt.smartcase = true
+
+-- Visual
+opt.number = true
+opt.cursorline = true
+opt.termguicolors = true
+opt.signcolumn = "yes"
+opt.wrap = false
+opt.scrolloff = 8
+opt.showmatch = true
+opt.laststatus = 2
+opt.shortmess:append("atI")
+
+-- Splits
+opt.splitbelow = true
+opt.splitright = true
+
+-- System
+opt.clipboard = "unnamed"
+opt.mouse = "a"
+opt.autoread = true
+opt.timeoutlen = 300
+opt.updatetime = 250
+opt.wildmenu = true
+opt.wildmode = "longest,list"
+opt.backspace = "indent,eol,start"
+
+-- No backup / swap
+opt.swapfile = false
+opt.backup = false
+opt.writebackup = false
+
+-- Persistent undo
+opt.undofile = true
+
+-- Diagnostics
+vim.diagnostic.config({
+  virtual_text = false,
+  signs = true,
+  float = { border = "rounded" },
+})

--- a/config/nvim/lua/plugins/colorscheme.lua
+++ b/config/nvim/lua/plugins/colorscheme.lua
@@ -1,0 +1,8 @@
+return {
+  "rose-pine/neovim",
+  name = "rose-pine",
+  priority = 1000,
+  lazy = false,
+  -- variant is set by config.appearance (reads state file), not here
+  opts = {},
+}

--- a/config/nvim/lua/plugins/completion.lua
+++ b/config/nvim/lua/plugins/completion.lua
@@ -1,0 +1,20 @@
+return {
+  "saghen/blink.cmp",
+  event = "InsertEnter",
+  version = "*",
+  opts = {
+    keymap = {
+      preset = "default",
+      ["<Tab>"] = { "select_next", "fallback" },
+      ["<S-Tab>"] = { "select_prev", "fallback" },
+      ["<CR>"] = { "accept", "fallback" },
+      ["<C-Space>"] = { "show" },
+    },
+    sources = {
+      default = { "lsp", "path", "buffer" },
+    },
+    completion = {
+      documentation = { auto_show = true },
+    },
+  },
+}

--- a/config/nvim/lua/plugins/editing.lua
+++ b/config/nvim/lua/plugins/editing.lua
@@ -1,0 +1,13 @@
+return {
+  {
+    "echasnovski/mini.surround",
+    event = "VeryLazy",
+    version = "*",
+    opts = {},
+  },
+  {
+    "windwp/nvim-autopairs",
+    event = "InsertEnter",
+    opts = {},
+  },
+}

--- a/config/nvim/lua/plugins/formatting.lua
+++ b/config/nvim/lua/plugins/formatting.lua
@@ -1,0 +1,37 @@
+return {
+  "stevearc/conform.nvim",
+  event = "BufWritePre",
+  keys = {
+    {
+      "<Leader>cf",
+      function()
+        require("conform").format({ async = true, lsp_fallback = true })
+      end,
+      desc = "Format file",
+    },
+  },
+  opts = {
+    formatters_by_ft = {
+      go = { "goimports" },
+      python = { "ruff_format" },
+      javascript = { "prettier" },
+      typescript = { "prettier" },
+      json = { "prettier" },
+      yaml = { "prettier" },
+      markdown = { "prettier" },
+      sh = { "shfmt" },
+      bash = { "shfmt" },
+      lua = { "stylua" },
+      terraform = { "terraform_fmt" },
+      tf = { "terraform_fmt" },
+    },
+    format_on_save = function(bufnr)
+      -- Skip if formatter is not available
+      local formatters = require("conform").list_formatters(bufnr)
+      if #formatters == 0 then
+        return
+      end
+      return { timeout_ms = 2000, lsp_fallback = true }
+    end,
+  },
+}

--- a/config/nvim/lua/plugins/git.lua
+++ b/config/nvim/lua/plugins/git.lua
@@ -1,0 +1,27 @@
+return {
+  {
+    "lewis6991/gitsigns.nvim",
+    event = { "BufReadPre", "BufNewFile" },
+    opts = {
+      on_attach = function(bufnr)
+        local gs = package.loaded.gitsigns
+        local map = function(mode, l, r, desc)
+          vim.keymap.set(mode, l, r, { buffer = bufnr, desc = desc })
+        end
+
+        map("n", "]h", gs.next_hunk, "Next hunk")
+        map("n", "[h", gs.prev_hunk, "Previous hunk")
+        map("n", "<Leader>hs", gs.stage_hunk, "Stage hunk")
+        map("n", "<Leader>hr", gs.reset_hunk, "Reset hunk")
+        map("n", "<Leader>gb", gs.blame_line, "Blame line")
+      end,
+    },
+  },
+  {
+    "tpope/vim-fugitive",
+    cmd = "Git",
+    keys = {
+      { "<Leader>gs", "<Cmd>Git<CR>", desc = "Git status" },
+    },
+  },
+}

--- a/config/nvim/lua/plugins/lsp.lua
+++ b/config/nvim/lua/plugins/lsp.lua
@@ -1,0 +1,62 @@
+return {
+  {
+    "neovim/nvim-lspconfig",
+    event = { "BufReadPre", "BufNewFile" },
+    dependencies = {
+      "williamboman/mason.nvim",
+      "williamboman/mason-lspconfig.nvim",
+    },
+    config = function()
+      require("mason").setup()
+      require("mason-lspconfig").setup({
+        ensure_installed = {
+          "gopls",
+          "lua_ls",
+          "pyright",
+          "ruby_lsp",
+          "ts_ls",
+          "terraformls",
+          "yamlls",
+          "jsonls",
+          "bashls",
+          "marksman",
+        },
+        -- automatic_enable (default true) auto-configures all installed servers
+      })
+
+      -- lua_ls: suppress undefined global `vim` warning
+      vim.lsp.config("lua_ls", {
+        settings = {
+          Lua = {
+            diagnostics = { globals = { "vim" } },
+            workspace = { checkThirdParty = false },
+            telemetry = { enable = false },
+          },
+        },
+      })
+
+      -- LspAttach keymaps
+      vim.api.nvim_create_autocmd("LspAttach", {
+        group = vim.api.nvim_create_augroup("LspKeymaps", { clear = true }),
+        callback = function(ev)
+          local map = function(keys, func, desc)
+            vim.keymap.set("n", keys, func, { buffer = ev.buf, desc = desc })
+          end
+
+          map("gd", vim.lsp.buf.definition, "Go to definition")
+          map("gr", vim.lsp.buf.references, "Go to references")
+          map("K", vim.lsp.buf.hover, "Hover documentation")
+          map("<Leader>ca", vim.lsp.buf.code_action, "Code action")
+          map("<Leader>rn", vim.lsp.buf.rename, "Rename")
+          map("[d", vim.diagnostic.goto_prev, "Previous diagnostic")
+          map("]d", vim.diagnostic.goto_next, "Next diagnostic")
+        end,
+      })
+    end,
+  },
+  {
+    "williamboman/mason.nvim",
+    cmd = "Mason",
+    opts = {},
+  },
+}

--- a/config/nvim/lua/plugins/lualine.lua
+++ b/config/nvim/lua/plugins/lualine.lua
@@ -1,0 +1,17 @@
+return {
+  "nvim-lualine/lualine.nvim",
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  opts = {
+    options = {
+      theme = "rose-pine",
+    },
+    sections = {
+      lualine_a = { "mode" },
+      lualine_b = { "branch", "diff", "diagnostics" },
+      lualine_c = { "filename" },
+      lualine_x = { "filetype" },
+      lualine_y = { "location" },
+      lualine_z = { "progress" },
+    },
+  },
+}

--- a/config/nvim/lua/plugins/neo-tree.lua
+++ b/config/nvim/lua/plugins/neo-tree.lua
@@ -1,0 +1,41 @@
+return {
+  "nvim-neo-tree/neo-tree.nvim",
+  branch = "v3.x",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "nvim-tree/nvim-web-devicons",
+    "MunifTanjim/nui.nvim",
+  },
+  keys = {
+    { "<Leader>e", "<Cmd>Neotree toggle<CR>", desc = "Toggle file explorer" },
+  },
+  cmd = "Neotree",
+  opts = {
+    filesystem = {
+      follow_current_file = { enabled = true },
+      filtered_items = {
+        visible = true,
+        hide_dotfiles = false,
+        hide_gitignored = false,
+      },
+    },
+    window = {
+      width = 35,
+    },
+    default_component_configs = {
+      git_status = {
+        symbols = {
+          added = "+",
+          modified = "~",
+          deleted = "x",
+          renamed = "r",
+          untracked = "?",
+          ignored = ".",
+          unstaged = "U",
+          staged = "S",
+          conflict = "!",
+        },
+      },
+    },
+  },
+}

--- a/config/nvim/lua/plugins/telescope.lua
+++ b/config/nvim/lua/plugins/telescope.lua
@@ -1,0 +1,24 @@
+return {
+  "nvim-telescope/telescope.nvim",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    { "nvim-telescope/telescope-fzf-native.nvim", build = "make" },
+  },
+  keys = {
+    { "<Leader>ff", "<Cmd>Telescope find_files<CR>", desc = "Find files" },
+    { "<Leader>fg", "<Cmd>Telescope live_grep<CR>", desc = "Live grep" },
+    { "<Leader>fb", "<Cmd>Telescope buffers<CR>", desc = "Buffers" },
+    { "<Leader>fh", "<Cmd>Telescope help_tags<CR>", desc = "Help tags" },
+    { "<Leader>fr", "<Cmd>Telescope oldfiles<CR>", desc = "Recent files" },
+    { "<Leader>fd", "<Cmd>Telescope diagnostics<CR>", desc = "Diagnostics" },
+  },
+  config = function()
+    local telescope = require("telescope")
+    telescope.setup({
+      defaults = {
+        file_ignore_patterns = { "node_modules", ".git/" },
+      },
+    })
+    telescope.load_extension("fzf")
+  end,
+}

--- a/config/nvim/lua/plugins/tmux-navigator.lua
+++ b/config/nvim/lua/plugins/tmux-navigator.lua
@@ -1,0 +1,4 @@
+return {
+  "christoomey/vim-tmux-navigator",
+  lazy = false,
+}

--- a/config/nvim/lua/plugins/treesitter.lua
+++ b/config/nvim/lua/plugins/treesitter.lua
@@ -1,0 +1,33 @@
+return {
+  "nvim-treesitter/nvim-treesitter",
+  event = { "BufReadPost", "BufNewFile" },
+  build = ":TSUpdate",
+  config = function()
+    require("nvim-treesitter").setup()
+
+    -- Enable treesitter-based highlighting and indentation
+    vim.treesitter.language.register("hcl", "terraform")
+
+    -- Auto-install parsers if missing (non-blocking)
+    local ensure = {
+      "bash", "go", "gomod", "gosum", "hcl", "terraform",
+      "javascript", "typescript", "json", "yaml", "toml",
+      "lua", "luadoc", "markdown", "markdown_inline",
+      "python", "ruby", "vim", "vimdoc", "regex",
+    }
+    local installed = require("nvim-treesitter").get_installed()
+    local installed_set = {}
+    for _, lang in ipairs(installed) do
+      installed_set[lang] = true
+    end
+    local missing = {}
+    for _, lang in ipairs(ensure) do
+      if not installed_set[lang] then
+        missing[#missing + 1] = lang
+      end
+    end
+    if #missing > 0 then
+      require("nvim-treesitter").install(missing)
+    end
+  end,
+}

--- a/config/nvim/lua/plugins/which-key.lua
+++ b/config/nvim/lua/plugins/which-key.lua
@@ -1,0 +1,13 @@
+return {
+  "folke/which-key.nvim",
+  event = "VeryLazy",
+  opts = {
+    spec = {
+      { "<Leader>f", group = "Find" },
+      { "<Leader>g", group = "Git" },
+      { "<Leader>c", group = "Code" },
+      { "<Leader>h", group = "Hunk" },
+      { "<Leader>s", group = "Split" },
+    },
+  },
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,6 +68,11 @@ dotfiles/
     ├── macos/                # macOS setup/defaults scripts
     ├── mise/                 # Runtime version manager config
     ├── nvim/                 # Neovim config (lazy.nvim)
+    │   ├── init.lua           # Bootstrap, leader, module loading
+    │   ├── lazy-lock.json     # Committed plugin lockfile
+    │   └── lua/
+    │       ├── config/        # options, keymaps, autocmds, appearance
+    │       └── plugins/       # One lazy.nvim spec per plugin concern
     ├── ripgrep/
     ├── sheldon/              # Zsh plugin manager config
     ├── ssh/                  # SSH config template (private hosts in ~/.ssh/config.local)
@@ -135,7 +140,7 @@ dotfiles/
 
 ### 3.6 Editor Configuration
 
-- **Neovim** (`config/nvim/`): lazy.nvim-based. Intended for desktop machines. Must open without blocking errors when an LSP or external tool is missing.
+- **Neovim** (`config/nvim/`): Modular lazy.nvim-based config for quick-edits workflow. Structure: `lua/config/` (options, keymaps, autocmds, appearance) + `lua/plugins/` (one spec per concern). Rose Pine Dawn light colorscheme with custom NordicPine dark colorscheme with live theme switching via `ThemeSwitch` command and remote socket. Mason-managed LSP servers, blink.cmp completion, conform.nvim formatting (format on save), Telescope file finding, neo-tree explorer, gitsigns + fugitive, treesitter, which-key, mini.surround + autopairs, vim-tmux-navigator. Must open without blocking errors when an LSP, formatter, or external tool is missing.
 - **Vim** (`config/vim/`): Symlinked as `~/.vim` → `config/vim/`. Must work on any remote server with stock vim and zero external dependencies. Includes `nordicpine` colorscheme (dark/light auto-detection).
 
 ### 3.8 Git Identity & Commit Signing

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -152,7 +152,7 @@ Bootstrap creates these directories automatically (`~/code/work/` only on work m
 
 ### Editors
 
-- **Neovim** (`config/nvim/`) — lazy.nvim-based IDE setup, used on desktop machines
+- **Neovim** (`config/nvim/`) — modular lazy.nvim-based config (see `docs/nvim.cheatsheet.md` for keymaps)
 - **Vim** (`config/vim/`) — minimal, no plugins, safe to use on any remote server with stock vim. Symlinked as `~/.vim` → `config/vim/` (vim auto-finds `~/.vim/vimrc`)
   - **Colorscheme:** `nordicpine` — dual-mode (NordicPine dark / AlpineDawn light), auto-detects macOS appearance, defaults to dark on Linux/remote
   - **Colors directory:** `config/vim/colors/nordicpine.vim` — available automatically via the `~/.vim` symlink
@@ -172,6 +172,7 @@ macOS appearance change
     → bin/theme-switch "dark"|"light"
       ├─ writes ~/.local/state/appearance
       ├─ tmux: sources tmux-nordic.conf or tmux-alpine.conf (immediate)
+      ├─ neovim: sends ThemeSwitch to all running instances via socket (immediate)
       ├─ btop: seds color_theme in btop.conf (next launch)
       └─ starship: seds palette line in starship.toml (next prompt)
 
@@ -188,6 +189,7 @@ Existing shell sessions:
 | bat | Immediately (`--theme=auto:system`) |
 | tmux | Immediately (theme-switch sources conf) |
 | starship | Next prompt |
+| Neovim | Immediately (theme-switch sends ThemeSwitch via socket) |
 | zsh syntax highlighting | Next prompt |
 | btop | Next launch |
 
@@ -391,10 +393,20 @@ git add dotbot
 git commit -m "update dotbot submodule"
 ```
 
-### Sync Neovim plugins
+### Neovim maintenance
 
 ```sh
-nvim --headless "+Lazy sync" +qa
+nvim --headless "+Lazy sync" +qa    # install/clean/update plugins
+nvim --headless "+MasonUpdate" +qa  # update Mason registries
+nvim --headless "+TSUpdate" +qa     # update treesitter parsers
+```
+
+After updating plugins, commit the lockfile:
+
+```sh
+cd ~/.dotfiles
+git add config/nvim/lazy-lock.json
+git commit -m "⬆️ Update nvim plugin lockfile"
 ```
 
 ### Update mise runtimes

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,10 +4,6 @@ Deferred ideas and future improvements.
 
 ---
 
-## Tool Overhauls
-
-- **Neovim config overhaul** — Separate project. Current config is intentionally stubbed out. Full lazy.nvim setup with LSP, treesitter, keymaps, plugins, etc. **Note:** vim-tmux-navigator plugin is installed in tmux and works between tmux panes, but integration with neovim panes requires the neovim counterpart plugin — defer full setup to neovim overhaul.
-
 ## Dotbot
 
 - **Dotbot deep audit and optimization** — Beyond basic cleanup: evaluate whether the submodule update should be automated/scripted, explore dotbot plugins or conditional directives, optimize `install.config.yaml` structure, ensure RUNBOOK maintenance docs are thorough.
@@ -24,3 +20,5 @@ Deferred ideas and future improvements.
 
 - **macOS defaults & OS customization** — Revisit `defaults write` settings for new machines: Dock config (auto-hide, icon size, remove default apps), keyboard repeat rate, trackpad settings, Finder preferences, screenshot location, etc. Consider reintroducing `config/macos/` with a `defaults.sh` script that bootstrap or install can call on macOS.
 - **Codeberg setup** — If/when you want to try Codeberg for personal projects: add SSH key, host entry in SSH config, any git host-level config. Low effort.
+- **Nerd/Powerline Fonts** - consider keeping terminal font(s) in repo; including install in bootstrap and/or docs
+- TODO: Consistent colors on all machines. Getting some weird issues with directory fg/bg in ls output on remote machines.

--- a/docs/nvim.cheatsheet.md
+++ b/docs/nvim.cheatsheet.md
@@ -1,0 +1,130 @@
+# Neovim Cheatsheet
+
+Leader key: `Space`
+
+---
+
+## Navigation
+
+| Key | Action |
+|-----|--------|
+| `<C-h/j/k/l>` | Navigate splits / tmux panes |
+| `<S-h>` | Previous buffer |
+| `<S-l>` | Next buffer |
+| `<Space>q` | Close buffer |
+| `<Space>sv` | Vertical split |
+| `<Space>sh` | Horizontal split |
+| `n` / `N` | Next/prev search (centered) |
+
+---
+
+## Editing
+
+| Key | Action |
+|-----|--------|
+| `jj` | Escape (insert mode) |
+| `<Space>/` | Clear search highlight |
+| `J` / `K` (visual) | Move selected lines down/up |
+| `sa{motion}{char}` | Add surround (e.g., `saiw"`) |
+| `sd{char}` | Delete surround |
+| `sr{old}{new}` | Replace surround |
+| Autopairs | Brackets/quotes auto-close |
+
+---
+
+## Find (Telescope)
+
+| Key | Action |
+|-----|--------|
+| `<Space>ff` | Find files |
+| `<Space>fg` | Live grep |
+| `<Space>fb` | Buffers |
+| `<Space>fh` | Help tags |
+| `<Space>fr` | Recent files |
+| `<Space>fd` | Diagnostics |
+
+**Inside Telescope:** `<C-n>`/`<C-p>` navigate, `<CR>` select, `<C-x>` horizontal split, `<C-v>` vertical split, `<Esc>` close.
+
+---
+
+## File Explorer (Neo-tree)
+
+| Key | Action |
+|-----|--------|
+| `<Space>e` | Toggle file explorer |
+
+---
+
+## LSP
+
+| Key | Action |
+|-----|--------|
+| `gd` | Go to definition |
+| `gr` | Go to references |
+| `K` | Hover documentation |
+| `<Space>ca` | Code action |
+| `<Space>rn` | Rename symbol |
+| `<Space>cd` | Diagnostic float |
+| `[d` / `]d` | Prev/next diagnostic |
+
+---
+
+## Formatting
+
+| Key | Action |
+|-----|--------|
+| `<Space>cf` | Format file (manual) |
+| (auto) | Format on save if formatter available |
+
+Configured formatters: goimports (Go), ruff_format (Python), prettier (JS/TS/JSON/YAML/Markdown), shfmt (shell), stylua (Lua), terraform_fmt (Terraform).
+
+---
+
+## Git
+
+| Key | Action |
+|-----|--------|
+| `<Space>gs` | Git status (fugitive) |
+| `<Space>gb` | Blame current line |
+| `<Space>hs` | Stage hunk |
+| `<Space>hr` | Reset hunk |
+| `]h` / `[h` | Next/prev hunk |
+
+---
+
+## Completion (blink.cmp)
+
+| Key | Action |
+|-----|--------|
+| `<Tab>` | Next item |
+| `<S-Tab>` | Previous item |
+| `<CR>` | Confirm selection |
+| `<C-Space>` | Trigger completion |
+
+---
+
+## Theme Switching
+
+```
+:ThemeSwitch dark     " switch to NordicPine
+:ThemeSwitch light    " switch to Rose Pine Dawn
+```
+
+Automatically synced by `theme-switch` script via dark-notify.
+
+---
+
+## Maintenance Commands
+
+| Command | Action |
+|---------|--------|
+| `:Lazy` | Plugin manager UI |
+| `:Lazy update` | Update plugins |
+| `:Lazy sync` | Install/clean/update plugins |
+| `:Mason` | LSP server manager UI |
+| `:MasonUpdate` | Update Mason registries |
+| `:TSUpdate` | Update treesitter parsers |
+| `:LspInfo` | Show attached LSP servers |
+| `:checkhealth` | Run health checks |
+
+Headless sync: `nvim --headless "+Lazy sync" +qa`

--- a/docs/tldr/my-nvim.page.md
+++ b/docs/tldr/my-nvim.page.md
@@ -1,0 +1,39 @@
+# my-nvim
+
+> Personal neovim keybindings from the dotfiles repo (lazy.nvim + LSP + Telescope).
+
+- Find files / live grep / buffers:
+
+`Space f f` / `Space f g` / `Space f b`
+
+- Toggle file explorer:
+
+`Space e`
+
+- Go to definition / references:
+
+`gd` / `gr`
+
+- Hover docs / code action / rename:
+
+`K` / `Space c a` / `Space r n`
+
+- Next/prev diagnostic:
+
+`]d` / `[d`
+
+- Git blame / stage hunk / reset hunk:
+
+`Space g b` / `Space h s` / `Space h r`
+
+- Format file manually:
+
+`Space c f`
+
+- Switch theme:
+
+`:ThemeSwitch dark` / `:ThemeSwitch light`
+
+- Plugin manager / LSP server manager:
+
+`:Lazy` / `:Mason`


### PR DESCRIPTION
## Summary

- Modular neovim config: `lua/config/` (options, keymaps, autocmds, appearance) + `lua/plugins/` (one lazy.nvim spec per concern)
- Rose Pine colorscheme with NordicPine highlight-group overrides for dark mode, unmodified Dawn for light mode
- Mason-managed LSP (10 servers), blink.cmp completion, conform.nvim format-on-save, Telescope, neo-tree, gitsigns + fugitive, treesitter, which-key, mini.surround + autopairs, vim-tmux-navigator
- Live theme switching via `ThemeSwitch` command + remote socket, integrated into `theme-switch`/dark-notify pipeline
- Cheatsheet (`docs/nvim.cheatsheet.md`), tldr page (`my-nvim`), and doc updates (ARCHITECTURE, RUNBOOK, TODO)

## Test plan

- [x] `nvim --headless +q` exits cleanly (no errors)
- [x] Opens with correct Rose Pine variant matching `~/.local/state/appearance`
- [x] `:ThemeSwitch light` / `:ThemeSwitch dark` toggles correctly in both directions
- [x] `theme-switch dark && theme-switch light` round-trips nvim along with other tools
- [x] `C-hjkl` navigates between nvim splits and tmux panes
- [x] LSP attaches on supported filetypes (`:LspInfo`)
- [x] Format on save works (Go, Lua, etc.), silently skips when formatter missing
- [x] Rename `~/.local/share/nvim/mason` — nvim still opens without blocking errors
- [x] `lazy-lock.json` is committed and tracks pinned versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)