### PR TITLE
Add Nerd Font cask to Brewfile

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,6 +102,7 @@ dotfiles/
 - **Remote baseline:** `config/bash/bashrc` provides a minimal `.bashrc` for remote servers — PATH, essential aliases only. No visual elements, does not mirror the full zsh setup.
 - **Entrypoint:** `zsh/zshrc.zsh` is the sole zsh entrypoint. It sources `zsh/lib/*.zsh` directly — no `shell/`, `os/`, or `env/` module tree.
 - **Plugin manager:** Sheldon (`config/sheldon/`) manages zsh plugins. Homebrew dependency. Initialization guarded with `command -v sheldon > /dev/null && [[ -t 1 ]]`.
+- **Terminal font:** `SauceCodePro Nerd Font Mono` is installed via `Brewfile.universal` (`font-sauce-code-pro-nerd-font` cask). Required by Ghostty config and Starship prompt glyphs. Remote machines don't need it — the local terminal renders all glyphs.
 - **Optional tool guards:** Tools that may not be installed on all machines (zoxide, thefuck, terraform, bat) are guarded with `command -v` checks. The installer's `bat cache --build` step is similarly guarded.
 
 ### 3.3 Machine-Specific PATH

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16,5 +16,4 @@ Deferred ideas and future improvements.
 
 - **macOS defaults & OS customization** — Revisit `defaults write` settings for new machines: Dock config (auto-hide, icon size, remove default apps), keyboard repeat rate, trackpad settings, Finder preferences, screenshot location, etc. Consider reintroducing `config/macos/` with a `defaults.sh` script that bootstrap or install can call on macOS.
 - **Codeberg setup** — If/when you want to try Codeberg for personal projects: add SSH key, host entry in SSH config, any git host-level config. Low effort.
-- **Nerd/Powerline Fonts** - consider keeping terminal font(s) in repo; including install in bootstrap and/or docs
 - TODO: Consistent colors on all machines. Getting some weird issues with directory fg/bg in ls output on remote machines.

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -90,6 +90,7 @@ cask "1password"
 cask "1password-cli"
 cask "firefox"
 cask "flameshot"
+cask "font-sauce-code-pro-nerd-font"  # terminal font (Ghostty + Starship glyphs)
 cask "ghostty"
 cask "google-chrome"
 cask "obsidian"


### PR DESCRIPTION
## Summary
- Add `font-sauce-code-pro-nerd-font` cask to `Brewfile.universal` — formalizes a silent dependency required by Ghostty config and Starship prompt glyphs
- Document the font dependency in `ARCHITECTURE.md` section 3.2
- Remove completed TODO item for Nerd/Powerline Fonts

## Test plan
- [x] Verified `brew info --cask font-sauce-code-pro-nerd-font` resolves without an explicit tap
- [x] `brew bundle --file=packages/Brewfile.universal` installs cleanly
- [x] Ghostty renders prompt glyphs correctly (no change from current behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)