### PR TITLE
✨ Add wallpaper management with auto dark/light switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ config/git/.gitconfig-work
 # Live theme-switched configs (mutable at runtime, initialized from *.default)
 config/btop/btop.conf
 config/starship/starship.toml
+
+# Downloaded wallpaper images (fetched from github at install time)
+wallpapers/*.jpg
+wallpapers/*.png
+wallpapers/*.jpeg

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -225,7 +225,60 @@ create_stub "$HOME/.ssh/config.local" \
 #     ForwardAgent yes" \
 "~/.ssh/config.local"
 
-# --- 9. Mise runtimes ---
+# --- 9. Display type detection (macOS only) ---
+# theme-switch auto-detects per-display aspect ratios at runtime, so this
+# fallback file is only used when system_profiler is unavailable.
+
+STATE_DIR="$HOME/.local/state"
+DISPLAY_TYPE_FILE="$STATE_DIR/display-type"
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  if [[ -f "$DISPLAY_TYPE_FILE" ]]; then
+    skip "Display type fallback: $(cat "$DISPLAY_TYPE_FILE")"
+  else
+    # Detect displays and summarize
+    has_ultrawide=false
+    has_widescreen=false
+    if command -v system_profiler &>/dev/null; then
+      while IFS= read -r line; do
+        if [[ "$line" =~ ([0-9]+)\ x\ ([0-9]+) ]]; then
+          w="${BASH_REMATCH[1]}"
+          h="${BASH_REMATCH[2]}"
+          if (( h > 0 && w * 10 / h >= 20 )); then
+            has_ultrawide=true
+          else
+            has_widescreen=true
+          fi
+        fi
+      done < <(system_profiler SPDisplaysDataType 2>/dev/null | grep -i "resolution:")
+    fi
+
+    if $has_ultrawide && $has_widescreen; then
+      info "Mixed displays detected (ultrawide + widescreen)"
+      info "theme-switch will auto-detect per display at runtime"
+      detected="widescreen"
+    elif $has_ultrawide; then
+      info "Ultrawide display detected"
+      detected="ultrawide"
+    else
+      detected="widescreen"
+    fi
+
+    # Confirm or override
+    read -rp "[→] Set fallback display type to '$detected'? [Y/n/override]: " yn
+    case "$yn" in
+      [Nn]*)
+        if [[ "$detected" == "ultrawide" ]]; then detected="widescreen"; else detected="ultrawide"; fi
+        ;;
+    esac
+
+    mkdir -p "$STATE_DIR"
+    echo "$detected" > "$DISPLAY_TYPE_FILE"
+    success "Display type fallback set: $detected"
+  fi
+fi
+
+# --- 10. Mise runtimes ---
 
 if command -v mise &>/dev/null; then
   read -rp "[→] Run mise install to provision runtimes? [Y/n]: " yn
@@ -238,7 +291,7 @@ if command -v mise &>/dev/null; then
   fi
 fi
 
-# --- 10. Summary ---
+# --- 11. Summary ---
 
 printf '\n%s=== Bootstrap complete ===%s\n\n' "$BOLD" "$RESET"
 

--- a/bin/theme-switch
+++ b/bin/theme-switch
@@ -55,3 +55,70 @@ if [[ -f "$starship_conf" ]]; then
     sed -i '' 's/^palette = "nordicpine"/palette = "alpinedawn"/' "$starship_conf"
   fi
 fi
+
+# Desktop wallpaper — switch via desktoppr (macOS only)
+# Detects per-display aspect ratio so mixed ultrawide + widescreen setups
+# each get the right wallpaper folder/image.
+if command -v desktoppr &>/dev/null; then
+  wallpaper_repo="$HOME/Pictures/wallpapers"
+  wallpaper_default="$HOME/.local/share/wallpapers"
+  default_display_type="widescreen"
+  [[ -f "$HOME/.local/state/display-type" ]] && default_display_type="$(cat "$HOME/.local/state/display-type")"
+
+  # Build array of display resolutions from system_profiler (index-ordered)
+  display_resolutions=()
+  if command -v system_profiler &>/dev/null; then
+    while IFS= read -r line; do
+      if [[ "$line" =~ ([0-9]+)\ x\ ([0-9]+) ]]; then
+        display_resolutions+=("${BASH_REMATCH[1]}x${BASH_REMATCH[2]}")
+      fi
+    done < <(system_profiler SPDisplaysDataType 2>/dev/null | grep -i "resolution:")
+  fi
+
+  # Classify a resolution as ultrawide (aspect ratio >= 2:1) or widescreen
+  _display_type() {
+    local res="$1"
+    if [[ "$res" =~ ^([0-9]+)x([0-9]+)$ ]]; then
+      local w="${BASH_REMATCH[1]}" h="${BASH_REMATCH[2]}"
+      if (( h > 0 && w * 10 / h >= 20 )); then
+        echo "ultrawide"
+        return
+      fi
+    fi
+    echo "widescreen"
+  }
+
+  # Set wallpaper for a single screen index
+  _set_wallpaper() {
+    local screen_idx="$1" display_type="$2"
+
+    # Tier 2: folder rotation from wallpapers repo
+    local tier2_dir="$wallpaper_repo/$display_type/$mode"
+    if [[ -d "$tier2_dir" ]] && { compgen -G "$tier2_dir/*.jpg" || compgen -G "$tier2_dir/*.png" || compgen -G "$tier2_dir/*.jpeg"; } &>/dev/null; then
+      desktoppr "$screen_idx" "$tier2_dir"
+    else
+      # Tier 1: single image from dotfiles defaults
+      for ext in jpg png; do
+        local wp="$wallpaper_default/$mode.$ext"
+        if [[ -f "$wp" ]]; then
+          desktoppr "$screen_idx" "$wp"
+          break
+        fi
+      done
+    fi
+  }
+
+  if [[ ${#display_resolutions[@]} -gt 0 ]]; then
+    # Per-display: classify each screen and set its wallpaper individually
+    for idx in "${!display_resolutions[@]}"; do
+      # Verify this screen index exists in desktoppr
+      if desktoppr "$idx" &>/dev/null; then
+        dt="$(_display_type "${display_resolutions[$idx]}")"
+        _set_wallpaper "$idx" "$dt"
+      fi
+    done
+  else
+    # Fallback: no resolution data, apply to all screens using default type
+    _set_wallpaper "all" "$default_display_type"
+  fi
+fi

--- a/bin/theme-switch
+++ b/bin/theme-switch
@@ -59,7 +59,8 @@ fi
 # Desktop wallpaper — switch via desktoppr (macOS only)
 # Detects per-display aspect ratio so mixed ultrawide + widescreen setups
 # each get the right wallpaper folder/image.
-if command -v desktoppr &>/dev/null; then
+desktoppr_bin="$(command -v desktoppr 2>/dev/null || echo /usr/local/bin/desktoppr)"
+if [[ -x "$desktoppr_bin" ]]; then
   wallpaper_repo="$HOME/Pictures/wallpapers"
   wallpaper_default="$HOME/.local/share/wallpapers"
   default_display_type="widescreen"
@@ -95,13 +96,13 @@ if command -v desktoppr &>/dev/null; then
     # Tier 2: folder rotation from wallpapers repo
     local tier2_dir="$wallpaper_repo/$display_type/$mode"
     if [[ -d "$tier2_dir" ]] && { compgen -G "$tier2_dir/*.jpg" || compgen -G "$tier2_dir/*.png" || compgen -G "$tier2_dir/*.jpeg"; } &>/dev/null; then
-      desktoppr "$screen_idx" "$tier2_dir"
+      "$desktoppr_bin" "$screen_idx" "$tier2_dir"
     else
       # Tier 1: single image from dotfiles defaults
       for ext in jpg png; do
         local wp="$wallpaper_default/$mode.$ext"
         if [[ -f "$wp" ]]; then
-          desktoppr "$screen_idx" "$wp"
+          "$desktoppr_bin" "$screen_idx" "$wp"
           break
         fi
       done
@@ -112,7 +113,7 @@ if command -v desktoppr &>/dev/null; then
     # Per-display: classify each screen and set its wallpaper individually
     for idx in "${!display_resolutions[@]}"; do
       # Verify this screen index exists in desktoppr
-      if desktoppr "$idx" &>/dev/null; then
+      if "$desktoppr_bin" "$idx" &>/dev/null; then
         dt="$(_display_type "${display_resolutions[$idx]}")"
         _set_wallpaper "$idx" "$dt"
       fi

--- a/bin/wallpaper-setup
+++ b/bin/wallpaper-setup
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# wallpaper-setup — upgrade from tier 1 (single image) to tier 2 (folder rotation)
+# Clones the wallpapers repo and configures display type for theme-switch
+
+set -euo pipefail
+
+wallpaper_repo="$HOME/Pictures/wallpapers"
+state_dir="$HOME/.local/state"
+
+echo "=== Wallpaper Setup ==="
+echo ""
+
+# Step 1: Clone wallpapers repo if needed
+if [[ -d "$wallpaper_repo" ]]; then
+  echo "Wallpapers repo already exists at $wallpaper_repo"
+else
+  echo "Cloning wallpapers repo to $wallpaper_repo..."
+  git clone https://github.com/devnall/wallpapers.git "$wallpaper_repo"
+  echo "Done."
+fi
+echo ""
+
+# Step 2: Display type detection + fallback
+# theme-switch auto-detects per-display at runtime, but a fallback is stored
+# for environments where system_profiler is unavailable.
+echo "theme-switch auto-detects per-display aspect ratios at runtime."
+echo "Mixed setups (ultrawide + widescreen) are handled automatically."
+echo ""
+echo "The fallback display type is used only when detection is unavailable."
+
+current_fallback="widescreen"
+if [[ -f "$state_dir/display-type" ]]; then
+  current_fallback="$(cat "$state_dir/display-type")"
+fi
+
+echo "  Current fallback: $current_fallback"
+echo ""
+echo "  1) widescreen"
+echo "  2) ultrawide"
+echo ""
+read -rp "Set fallback display type [keep current]: " choice
+case "${choice:-}" in
+  1) current_fallback="widescreen" ;;
+  2) current_fallback="ultrawide" ;;
+  "") ;; # keep current
+  *)
+    echo "Invalid choice, keeping '$current_fallback'."
+    ;;
+esac
+
+mkdir -p "$state_dir"
+echo "$current_fallback" > "$state_dir/display-type"
+echo "Fallback display type: $current_fallback"
+echo ""
+
+# Step 3: Check folder structure
+echo "Checking wallpapers repo folder structure..."
+missing=()
+for dt in widescreen ultrawide; do
+  for m in dark light; do
+    if [[ ! -d "$wallpaper_repo/$dt/$m" ]]; then
+      missing+=("$dt/$m")
+    fi
+  done
+done
+
+if [[ ${#missing[@]} -eq 0 ]]; then
+  echo "Folder structure looks good."
+else
+  echo "Missing folders (create and add wallpapers for tier 2 rotation):"
+  for d in "${missing[@]}"; do
+    echo "  $wallpaper_repo/$d/"
+  done
+  echo ""
+  echo "Expected structure:"
+  echo "  $wallpaper_repo/"
+  echo "  ├── widescreen/"
+  echo "  │   ├── dark/"
+  echo "  │   └── light/"
+  echo "  └── ultrawide/"
+  echo "      ├── dark/"
+  echo "      └── light/"
+fi
+echo ""
+
+# Step 4: Apply current mode
+if [[ -f "$state_dir/appearance" ]]; then
+  current_mode="$(cat "$state_dir/appearance")"
+  echo "Applying current mode ($current_mode)..."
+  theme_switch="$(dirname "$0")/theme-switch"
+  if [[ -x "$theme_switch" ]]; then
+    "$theme_switch" "$current_mode"
+    echo "Done."
+  else
+    echo "Could not find theme-switch. Run manually: theme-switch $current_mode"
+  fi
+else
+  echo "No appearance state found at $state_dir/appearance."
+  echo "Run 'theme-switch dark' or 'theme-switch light' to apply."
+fi

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -49,6 +49,7 @@ dotfiles/
 │   ├── personal.zsh          # Sourced when ~/.personal exists
 │   ├── remote.zsh            # Sourced when ~/.remote exists
 │   └── remote-full.zsh       # Sourced when ~/.remote-full exists
+├── wallpapers/              # Default dark/light wallpapers (symlinked to ~/.local/share/wallpapers)
 ├── packages/
 │   ├── Brewfile.universal    # Installed on all machines
 │   ├── Brewfile.work         # Installed on work machines only

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -199,6 +199,9 @@ macOS appearance change
 Existing shell sessions:
   → precmd hook in theme.zsh reads ~/.local/state/appearance
   → re-applies syntax highlighting + autosuggestion colors if changed
+
+Desktop wallpaper (macOS):
+  → desktoppr sets wallpaper from tier 2 folder or tier 1 single image
 ```
 
 ### Tools and their response time
@@ -210,6 +213,7 @@ Existing shell sessions:
 | tmux | Immediately (theme-switch sources conf) |
 | starship | Next prompt |
 | Neovim | Immediately (theme-switch sends ThemeSwitch via socket) |
+| Desktop wallpaper | Immediately (desktoppr) |
 | zsh syntax highlighting | Next prompt |
 | btop | Next launch |
 
@@ -225,6 +229,27 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.dnall.dark-notify.pl
 **Manual trigger:**
 ```sh
 ~/.dotfiles/bin/theme-switch dark   # or light
+```
+
+### Wallpapers
+
+**Tier 1 (bootstrap default):** `./install` downloads a default dark + light wallpaper from the [wallpapers repo](https://github.com/devnall/wallpapers/) into `wallpapers/`, which is symlinked to `~/.local/share/wallpapers/`. `theme-switch` picks `dark.jpg` or `light.jpg` based on current mode. Downloads are skipped if the files already exist.
+
+To replace defaults, swap `wallpapers/dark.jpg` / `wallpapers/light.jpg` with your preferred images (`.jpg` or `.png`). Replacements are gitignored and won't be overwritten.
+
+**Tier 2 (folder rotation):** Clone the full wallpapers repo and enable multi-wallpaper rotation:
+
+```sh
+bin/wallpaper-setup
+```
+
+This clones `https://github.com/devnall/wallpapers.git` to `~/Pictures/wallpapers/`, prompts for display type (widescreen/ultrawide), and writes `~/.local/state/display-type`. When the tier 2 folder exists with images, `theme-switch` passes the folder to `desktoppr` for rotation.
+
+**Display type:** Auto-detected per display at runtime (ultrawide = aspect ratio >= 2:1). Mixed setups (ultrawide + widescreen) are handled automatically. Fallback stored at `~/.local/state/display-type` (defaults to `widescreen`).
+
+**Manual set:**
+```sh
+desktoppr ~/.local/share/wallpapers/dark.jpg
 ```
 
 **Check state file:**
@@ -346,6 +371,7 @@ dotfiles/
 │   ├── personal.zsh          # Sourced when ~/.personal exists
 │   ├── remote-full.zsh       # Sourced when ~/.remote-full exists (Linux + Homebrew)
 │   └── remote.zsh            # Sourced when ~/.remote exists (minimal Linux servers)
+├── wallpapers/              # Default dark/light wallpapers (symlinked to ~/.local/share/wallpapers)
 ├── packages/
 │   ├── Brewfile.universal    # Installed on every machine
 │   ├── Brewfile.work         # Installed when ~/.work exists

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -94,6 +94,11 @@
       path: config/claude/statusline-command.sh
       force: true
 
+    # Wallpapers
+    ~/.local/share/wallpapers:
+      path: wallpapers
+      force: true
+
     # macOS-specific
     ~/Library/LaunchAgents/com.dnall.dark-notify.plist:
       path: config/launchagents/com.dnall.dark-notify.plist
@@ -127,6 +132,19 @@
     -
      command: 'command -v bat > /dev/null && bat cache --build || true'
      description: Build bat theme cache
+     stdout: true
+    -
+     command: |
+       wp_dir="wallpapers"
+       base_url="https://raw.githubusercontent.com/devnall/wallpapers/main/widescreen"
+       for pair in "dark.jpg:Minimal_BlackWaves.jpg" "light.jpg:Texture_BrownGradient.jpg"; do
+         local_name="${pair%%:*}"
+         remote_name="${pair##*:}"
+         if [[ ! -f "$wp_dir/$local_name" ]]; then
+           curl -fsSL "$base_url/$remote_name" -o "$wp_dir/$local_name" 2>/dev/null && echo "Downloaded $local_name" || echo "⚠ Failed to download $local_name"
+         fi
+       done
+     description: Download default wallpapers if missing
      stdout: true
     -
      command: 'command -v pre-commit > /dev/null && [ -d .git ] && pre-commit install || true'

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -84,6 +84,7 @@ brew "shellcheck"
 # brew "rust"         # managed via rustup/mise
 
 # Casks
+cask "desktoppr"           # set desktop wallpaper
 cask "docker-desktop"
 cask "latest"              # app update checker
 cask "1password"

--- a/wallpapers/README.md
+++ b/wallpapers/README.md
@@ -1,0 +1,63 @@
+# Wallpapers
+
+Default wallpapers for automatic dark/light switching.
+
+## How it works
+
+```
+macOS appearance change
+  → dark-notify → bin/theme-switch
+    → desktoppr sets wallpaper from dark.* or light.*
+```
+
+`theme-switch` checks for images at `~/.local/share/wallpapers/` (symlinked here by dotbot). It looks for `dark.jpg`, `dark.png`, `light.jpg`, or `light.png` — first match wins.
+
+Default images (`dark.jpg`, `light.jpg`) are downloaded from the [wallpapers repo](https://github.com/devnall/wallpapers/) at `./install` time. They are gitignored — not stored in this repo.
+
+## Replacing defaults
+
+Swap `dark.jpg` / `light.jpg` with your preferred images. Both `.jpg` and `.png` are supported — just name them `dark.<ext>` / `light.<ext>`. Your replacements are gitignored and won't be overwritten by `./install` (download only runs if the file is missing).
+
+## Tier 2: Full wallpaper rotation
+
+For folder-based rotation with multiple wallpapers per mode:
+
+```sh
+bin/wallpaper-setup
+```
+
+This clones the full wallpapers repo to `~/Pictures/wallpapers/`, prompts for display type (widescreen/ultrawide), and enables folder-based rotation. When a tier 2 folder exists with images, `theme-switch` uses `desktoppr` folder rotation instead of the single-image default.
+
+### Wallpapers repo
+
+Source: https://github.com/devnall/wallpapers/
+
+Expected folder structure:
+```
+~/Pictures/wallpapers/
+├── widescreen/
+│   ├── dark/
+│   └── light/
+├── ultrawide/
+│   ├── dark/
+│   └── light/
+└── mobile/
+    ├── dark/
+    └── light/
+```
+
+## Display type
+
+`theme-switch` auto-detects each display's aspect ratio at runtime via `system_profiler`. Mixed setups (e.g. one ultrawide + one widescreen) are handled automatically — each screen gets wallpapers from its matching folder.
+
+A fallback display type at `~/.local/state/display-type` is used only when `system_profiler` is unavailable (defaults to `widescreen`):
+
+```sh
+echo "ultrawide" > ~/.local/state/display-type
+```
+
+## Manual wallpaper set
+
+```sh
+desktoppr ~/.local/share/wallpapers/dark.jpg
+```


### PR DESCRIPTION
## Summary

- Two-tier wallpaper system integrated into the `dark-notify` → `theme-switch` pipeline
- **Tier 1:** Default `dark.jpg` + `light.jpg` downloaded from the [wallpapers repo](https://github.com/devnall/wallpapers/) at `./install` time (images gitignored, not stored in repo)
- **Tier 2:** `bin/wallpaper-setup` clones the full wallpapers repo to `~/Pictures/wallpapers/` for folder-based rotation with multiple wallpapers per mode
- Per-display aspect ratio detection via `system_profiler` — mixed ultrawide + widescreen setups get the right wallpapers on each screen automatically
- Bootstrap detects display types and writes a fallback to `~/.local/state/display-type`
- `desktoppr` (new cask) sets wallpapers per screen index

## Files changed

| File | Change |
|------|--------|
| `packages/Brewfile.universal` | Add `cask "desktoppr"` |
| `wallpapers/README.md` | New — usage docs for wallpaper system |
| `.gitignore` | Exclude downloaded wallpaper images |
| `install.config.yaml` | Wallpaper symlink + download step |
| `bin/theme-switch` | Per-display wallpaper switching block |
| `bin/wallpaper-setup` | New — tier 2 setup script |
| `bin/bootstrap.sh` | Display type detection step |
| `docs/ARCHITECTURE.md` | Add `wallpapers/` to directory tree |
| `docs/RUNBOOK.md` | Wallpaper section, directory tree, tools table |

## Test plan

- [x] `./install` — confirm wallpapers download and symlink at `~/.local/share/wallpapers/`
- [x] `theme-switch dark` / `theme-switch light` — confirm wallpaper changes
- [x] Toggle macOS appearance — confirm automatic switch via dark-notify
- [x] `bin/wallpaper-setup` — confirm clone + display type prompt
- [x] Verify per-display detection with mixed monitors (ultrawide + widescreen)
- [x] Delete `wallpapers/dark.jpg`, re-run `./install` — confirm re-download

🤖 Generated with [Claude Code](https://claude.com/claude-code)