### PR TITLE
✨ Add Brewfile.local for machine-specific packages

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -225,6 +225,15 @@ create_stub "$HOME/.ssh/config.local" \
 #     ForwardAgent yes" \
 "~/.ssh/config.local"
 
+create_stub "$DOTFILES_DIR/packages/Brewfile.local" \
+"# Local Brewfile — machine-specific packages
+# Run: brew bundle --file=packages/Brewfile.local
+# This file is gitignored. Use it for packages you only want on this machine.
+
+# brew \"example\"
+# cask \"example\"" \
+"packages/Brewfile.local"
+
 # --- 9. Display type detection (macOS only) ---
 # theme-switch auto-detects per-display aspect ratios at runtime, so this
 # fallback file is only used when system_profiler is unavailable.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,7 +53,8 @@ dotfiles/
 ├── packages/
 │   ├── Brewfile.universal    # Installed on all machines
 │   ├── Brewfile.work         # Installed on work machines only
-│   └── Brewfile.personal     # Installed on personal machines only
+│   ├── Brewfile.personal     # Installed on personal machines only
+│   └── Brewfile.local        # Machine-specific (gitignored, create per machine)
 └── config/                   # XDG-style tool configs
     ├── bash/bashrc           # Minimal bash (remote server baseline only)
     ├── bat/

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -27,7 +27,7 @@ The bootstrap wizard is interactive and idempotent — it skips anything already
 - **Git identity** — copies `config/git/.gitconfig-user.example` → `.gitconfig-user` if missing. Edit this file with your name, email, and signingkey
 - **Code directories** — creates `~/code/personal/` on all machines, `~/code/work/` on work machines only
 - **Work git identity** (work machines only) — copies `config/git/.gitconfig-work.example` → `.gitconfig-work` if missing. Edit with your work name, email, and signingkey
-- **Stub files** — creates `~/.env.local`, `~/.secrets.local`, and `~/.ssh/config.local` with commented templates if they don't exist
+- **Stub files** — creates `~/.env.local`, `~/.secrets.local`, `~/.ssh/config.local`, and `packages/Brewfile.local` with commented templates if they don't exist
 
 ### 3. Run the installer
 
@@ -37,7 +37,7 @@ The bootstrap wizard is interactive and idempotent — it skips anything already
 
 This will:
 - Create all symlinks (zshrc, nvim, tmux, ghostty, starship, bat, btop, etc.)
-- Run `brew bundle` for `Brewfile.universal`, plus `Brewfile.work` or `Brewfile.personal` based on the marker file
+- Run `brew bundle` for `Brewfile.universal`, plus `Brewfile.work` or `Brewfile.personal` based on the marker file, plus `Brewfile.local` if it exists
 
 ### 4. Install runtimes
 
@@ -375,7 +375,8 @@ dotfiles/
 ├── packages/
 │   ├── Brewfile.universal    # Installed on every machine
 │   ├── Brewfile.work         # Installed when ~/.work exists
-│   └── Brewfile.personal     # Installed when ~/.personal exists
+│   ├── Brewfile.personal     # Installed when ~/.personal exists
+│   └── Brewfile.local        # Machine-specific (gitignored, create per machine)
 ├── zsh/
 │   ├── zshrc.zsh             # Symlinked to ~/.zshrc
 │   ├── lib/                  # Auto-sourced by zshrc (alphabetical order)
@@ -563,6 +564,7 @@ Add to the appropriate Brewfile and run `./install` (or `brew bundle` directly):
 - `packages/Brewfile.universal` — install everywhere
 - `packages/Brewfile.work` — work machines only
 - `packages/Brewfile.personal` — personal machines only
+- `packages/Brewfile.local` — this machine only (gitignored)
 
 ### New zsh config
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16,4 +16,3 @@ Deferred ideas and future improvements.
 
 - **Codeberg setup** — If/when you want to try Codeberg for personal projects: add SSH key, host entry in SSH config, any git host-level config. Low effort.
 - TODO: Consistent colors on all machines. Getting some weird issues with directory fg/bg in ls output on remote machines.
-- TODO: Consider a Brewfile.local. Gitignored. Does that even make sense? Does it have any benefit over just brew installing the package?

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -130,6 +130,10 @@
      description: Install personal Homebrew packages
      stdout: true
     -
+     command: '[[ -f packages/Brewfile.local ]] && brew bundle --file=packages/Brewfile.local || true'
+     description: Install local Homebrew packages
+     stdout: true
+    -
      command: 'command -v bat > /dev/null && bat cache --build || true'
      description: Build bat theme cache
      stdout: true


### PR DESCRIPTION
## Summary
- Adds a gitignored `packages/Brewfile.local` for packages that should only be installed on one machine
- `./install` runs `brew bundle` on it when present (no marker file needed — inherently per-machine)
- Bootstrap creates the stub file alongside other `.local` stubs
- Updated docs (ARCHITECTURE.md, RUNBOOK.md, TODO.md)

## Test plan
- [ ] `git status` confirms `packages/Brewfile.local` is not tracked
- [ ] `./install` runs cleanly and processes the local Brewfile
- [ ] Removing `Brewfile.local` doesn't break `./install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)