### PR TITLE
🔧 Complete application audit across all machines

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -329,6 +329,9 @@ fi
 if [[ -f "$HOME/.ssh/config.local" ]] && ! grep -qv '^#' "$HOME/.ssh/config.local" 2>/dev/null; then
   todos+=("Add host entries to ~/.ssh/config.local")
 fi
+if [[ -f "$HOME/.personal" ]]; then
+  todos+=("Install manually-managed apps — see docs/RUNBOOK.md § Manual applications")
+fi
 
 if [[ ${#todos[@]} -gt 0 ]]; then
   info "TODO:"

--- a/bin/brew-audit.sh
+++ b/bin/brew-audit.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# brew-audit.sh — Brewfile drift detection report
+#
+# Compares what's installed on this machine against what's tracked in
+# Brewfiles. Outputs a report grouped by category. Does not modify anything.
+#
+# Usage:
+#   brew-audit        # run via ~/bin symlink
+#   bin/brew-audit.sh # run directly
+
+set -uo pipefail
+
+# --- Resolve dotfiles directory ---
+
+if [[ -n "${DOTFILES:-}" ]]; then
+  DOTFILES_DIR="$DOTFILES"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")")" && pwd)"
+  DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+PACKAGES_DIR="$DOTFILES_DIR/packages"
+
+# --- Output helpers ---
+
+tput_available() { command -v tput >/dev/null 2>&1; }
+
+if tput_available; then
+  BOLD=$(tput bold)
+  GREEN=$(tput setaf 2)
+  YELLOW=$(tput setaf 3)
+  RED=$(tput setaf 1)
+  DIM=$(tput dim)
+  RESET=$(tput sgr0)
+else
+  BOLD="" GREEN="" YELLOW="" RED="" DIM="" RESET=""
+fi
+
+header()  { printf '\n%s=== %s ===%s\n' "$BOLD" "$1" "$RESET"; }
+ok()      { printf '  %s✓%s %s\n' "$GREEN" "$RESET" "$1"; }
+finding() { printf '  %s•%s %s\n' "$YELLOW" "$RESET" "$1"; }
+info()    { printf '  %s%s%s\n' "$DIM" "$1" "$RESET"; }
+
+# --- Detect machine type ---
+
+machine_type="unknown"
+if [[ -f "$HOME/.work" ]]; then
+  machine_type="work"
+elif [[ -f "$HOME/.personal" ]]; then
+  machine_type="personal"
+elif [[ -f "$HOME/.remote-full" ]]; then
+  machine_type="remote-full"
+elif [[ -f "$HOME/.remote" ]]; then
+  machine_type="remote"
+fi
+
+printf '%sBrew Audit Report%s — %s (%s)\n' "$BOLD" "$RESET" "$(hostname -s)" "$machine_type"
+printf '%s\n' "$(date '+%Y-%m-%d %H:%M')"
+
+# --- Check prerequisites ---
+
+if ! command -v brew &>/dev/null; then
+  printf '%sError:%s Homebrew not found\n' "$RED" "$RESET" >&2
+  exit 1
+fi
+
+# --- Build list of applicable Brewfiles ---
+
+brewfiles=()
+[[ -f "$PACKAGES_DIR/Brewfile.universal" ]] && brewfiles+=("$PACKAGES_DIR/Brewfile.universal")
+if [[ "$machine_type" == "work" ]] && [[ -f "$PACKAGES_DIR/Brewfile.work" ]]; then
+  brewfiles+=("$PACKAGES_DIR/Brewfile.work")
+fi
+if [[ "$machine_type" == "personal" ]] && [[ -f "$PACKAGES_DIR/Brewfile.personal" ]]; then
+  brewfiles+=("$PACKAGES_DIR/Brewfile.personal")
+fi
+[[ -f "$PACKAGES_DIR/Brewfile.local" ]] && brewfiles+=("$PACKAGES_DIR/Brewfile.local")
+
+info "Brewfiles: ${brewfiles[*]##*/}"
+
+# --- Parse active (non-commented) entries from Brewfiles ---
+
+parse_brewfile_entries() {
+  local entry_type="$1"
+  shift
+  for bf in "$@"; do
+    grep -E "^${entry_type} " "$bf" 2>/dev/null | \
+      sed -E "s/^${entry_type} \"([^\"]+)\".*/\1/" || true
+  done | sort -u
+}
+
+tracked_formulae=$(parse_brewfile_entries "brew" "${brewfiles[@]}")
+tracked_casks=$(parse_brewfile_entries "cask" "${brewfiles[@]}")
+tracked_mas=$(for bf in "${brewfiles[@]}"; do
+  grep -E '^mas ' "$bf" 2>/dev/null | sed -E 's/.*id: ([0-9]+).*/\1/' || true
+done | sort -u)
+
+# --- Get installed state ---
+
+installed_leaves=$(brew leaves 2>/dev/null | sort)
+installed_casks=$(brew list --cask 2>/dev/null | sort)
+installed_mas=""
+if command -v mas &>/dev/null; then
+  installed_mas=$(mas list 2>/dev/null | awk '{print $1}' | sort)
+fi
+
+# --- 1. Installed formulae not in any Brewfile ---
+
+header "Installed formulae (leaves) not in any Brewfile"
+count=0
+while IFS= read -r formula; do
+  [[ -z "$formula" ]] && continue
+  if ! echo "$tracked_formulae" | grep -qxF "$formula"; then
+    finding "$formula"
+    ((count++)) || true
+  fi
+done <<< "$installed_leaves"
+[[ $count -eq 0 ]] && ok "All installed formulae are tracked"
+
+# --- 2. Installed casks not in any Brewfile ---
+
+header "Installed casks not in any Brewfile"
+count=0
+while IFS= read -r cask_name; do
+  [[ -z "$cask_name" ]] && continue
+  if ! echo "$tracked_casks" | grep -qxF "$cask_name"; then
+    finding "$cask_name"
+    ((count++)) || true
+  fi
+done <<< "$installed_casks"
+[[ $count -eq 0 ]] && ok "All installed casks are tracked"
+
+# --- 3. Installed MAS apps not in any Brewfile ---
+
+header "Installed MAS apps not in any Brewfile"
+count=0
+if [[ -n "$installed_mas" ]]; then
+  while IFS= read -r mas_id; do
+    [[ -z "$mas_id" ]] && continue
+    if ! echo "$tracked_mas" | grep -qxF "$mas_id"; then
+      # Look up the name from mas list
+      mas_name=$(mas list 2>/dev/null | grep " *${mas_id} " | sed "s/^ *[0-9]* *//" | sed 's/ *(.*//')
+      finding "$mas_name ($mas_id)"
+      ((count++)) || true
+    fi
+  done <<< "$installed_mas"
+fi
+[[ $count -eq 0 ]] && ok "All MAS apps are tracked"
+
+# --- 4. Brewfile entries not installed ---
+
+header "Brewfile entries not installed on this machine"
+count=0
+
+# Use pre-fetched lists instead of per-entry brew list calls (much faster)
+installed_all_formulae=$(brew list --formula 2>/dev/null | sort)
+
+while IFS= read -r formula; do
+  [[ -z "$formula" ]] && continue
+  # Strip tap prefix for matching (e.g. "cormacrelf/tap/dark-notify" -> "dark-notify")
+  short_name="${formula##*/}"
+  if ! echo "$installed_all_formulae" | grep -qxF "$short_name"; then
+    finding "formula: $formula"
+    ((count++)) || true
+  fi
+done <<< "$tracked_formulae"
+
+while IFS= read -r cask_name; do
+  [[ -z "$cask_name" ]] && continue
+  if ! echo "$installed_casks" | grep -qxF "$cask_name"; then
+    finding "cask: $cask_name"
+    ((count++)) || true
+  fi
+done <<< "$tracked_casks"
+
+if command -v mas &>/dev/null && [[ -n "$tracked_mas" ]]; then
+  while IFS= read -r mas_id; do
+    [[ -z "$mas_id" ]] && continue
+    if ! echo "$installed_mas" | grep -qxF "$mas_id"; then
+      # Look up name from Brewfile
+      mas_name=""
+      for bf in "${brewfiles[@]}"; do
+        mas_name=$(grep -E "id: ${mas_id}" "$bf" 2>/dev/null | sed -E 's/^mas "([^"]+)".*/\1/' || true)
+        [[ -n "$mas_name" ]] && break
+      done
+      finding "mas: ${mas_name:-$mas_id} ($mas_id)"
+      ((count++)) || true
+    fi
+  done <<< "$tracked_mas"
+fi
+
+[[ $count -eq 0 ]] && ok "All Brewfile entries are installed"
+
+# --- 5. Apps in /Applications not managed by Homebrew or MAS ---
+
+header "Apps in /Applications not managed by Homebrew or MAS"
+count=0
+
+# Build lookup of managed app names (lowercase, no .app suffix)
+# Use Homebrew's caskroom receipts (fast, no network) + MAS names
+managed_apps=$(
+  {
+    # Cask apps: read app names from caskroom receipts
+    for cask_dir in "$(brew --prefix)"/Caskroom/*/; do
+      [[ -d "$cask_dir" ]] || continue
+      # Find .app artifacts in the latest version directory
+      latest=$(find "$cask_dir" -maxdepth 1 -mindepth 1 -type d -print 2>/dev/null | sort | tail -1)
+      latest="${latest##*/}"
+      [[ -z "$latest" ]] && continue
+      if [[ -f "$cask_dir/$latest/.metadata" ]]; then
+        # Fall back to cask name (hyphen to space, capitalize)
+        basename "$cask_dir"
+      else
+        basename "$cask_dir"
+      fi
+    done
+
+    # MAS apps: names from mas list
+    if [[ -n "$installed_mas" ]]; then
+      mas list 2>/dev/null | sed 's/^[0-9]* *//' | sed 's/ *(.*//'
+    fi
+  } | tr '[:upper:]' '[:lower:]' | sort -u
+)
+
+# System/Apple apps and non-app directories to skip
+skip_apps="garageband|imovie|safari|utilities|xcode|include|lib"
+
+for app_dir in /Applications ~/Applications; do
+  [[ -d "$app_dir" ]] || continue
+  while IFS= read -r app; do
+    # Strip path and .app suffix
+    name="${app##*/}"
+    name="${name%.app}"
+    name_lower=$(echo "$name" | tr '[:upper:]' '[:lower:]')
+
+    # Skip non-.app entries, system apps, and localized dirs
+    [[ "$app" != *.app ]] && continue
+    echo "$name_lower" | grep -qiE "^($skip_apps)$" && continue
+
+    # Normalize for matching: "Docker Desktop" matches cask "docker-desktop"
+    name_hyphenated="${name_lower// /-}"
+
+    # Check if managed by cask name or app name
+    if ! echo "$managed_apps" | grep -qixF "$name_lower" && \
+       ! echo "$managed_apps" | grep -qixF "$name_hyphenated" && \
+       ! echo "$installed_casks" | grep -qixF "$name_hyphenated"; then
+      finding "$name ($app_dir/)"
+      ((count++)) || true
+    fi
+  done < <(ls "$app_dir" 2>/dev/null)
+done
+
+[[ $count -eq 0 ]] && ok "All applications are tracked"
+
+# --- Summary ---
+
+printf '\n%sDone.%s Run this after Brewfile changes or on new machines.\n' "$BOLD" "$RESET"
+printf 'Decision framework: add to Brewfile / quarantine / uninstall / leave as manual\n'
+printf 'See docs/RUNBOOK.md for details.\n\n'

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -117,6 +117,8 @@ dotfiles/
 - **Detection:** Marker file approach — one of `~/.work`, `~/.personal`, `~/.remote-full`, or `~/.remote` is touched during machine setup. No hostname detection.
 - **Shell loader:** Sources the corresponding `env/*.zsh` file. If no marker exists, only universal config loads.
 - **Dotbot install:** Runs `brew bundle` for the appropriate Brewfile(s) based on marker.
+- **Mac App Store apps:** Tracked via `mas "Name", id: 123456` entries in Brewfiles. The `mas` CLI is in `Brewfile.universal`.
+- **Manually-installed apps:** Audio production software (Native Instruments, IK Multimedia, etc.) is installed via vendor-specific managers, not Homebrew. Platform managers and standalone apps are documented as `# Download:` comments in `Brewfile.personal`.
 - **Marker definitions:**
   - `~/.work` — work machine (full macOS setup)
   - `~/.personal` — personal machine (full macOS setup)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -431,13 +431,58 @@ brew bundle --file=~/.dotfiles/packages/Brewfile.universal
 
 ### Check for Brewfile drift
 
-Packages accumulate outside the Brewfile over time. Audit with:
+Run the audit script to get a full drift report:
+
+```sh
+brew-audit
+```
+
+This compares `brew leaves`, `brew list --cask`, and `mas list` against all applicable Brewfiles (auto-detected from marker file). Output is grouped into:
+
+1. Installed formulae not in any Brewfile
+2. Installed casks not in any Brewfile
+3. Installed MAS apps not in any Brewfile
+4. Brewfile entries not installed on this machine
+5. Apps in /Applications not managed by Homebrew or MAS
+
+**When to run:** After major Brewfile changes, when setting up a new machine, or periodically (quarterly).
+
+**Decision framework for each finding:**
+- **Add to Brewfile** — if you want it tracked and installed on new machines
+- **Quarantine** — if unsure; comment it out with a datestamp (delete after 6 months if still unused)
+- **Uninstall** — `brew uninstall <name>` for packages you no longer need
+- **Leave as manual** — for vendor-installed apps (audio production, drivers) that aren't in Homebrew
+
+For targeted drift checks, `brew bundle` commands are also available:
 
 ```sh
 brew bundle check --file=~/.dotfiles/packages/Brewfile.universal
 brew bundle cleanup --file=~/.dotfiles/packages/Brewfile.universal  # shows what would be removed
 brew bundle cleanup --force --file=~/.dotfiles/packages/Brewfile.universal  # actually removes them
 ```
+
+### Mac App Store apps
+
+MAS apps are tracked in Brewfiles using `mas "App Name", id: 123456` syntax. The `mas` CLI is installed via `Brewfile.universal`.
+
+```sh
+mas list                    # list installed MAS apps with IDs
+mas search "App Name"       # find an app's ID
+```
+
+`brew bundle` handles `mas` entries automatically alongside formulae and casks. Requirements:
+- Must be signed into the Mac App Store
+- Paid apps must have been purchased previously (mas cannot buy apps)
+- `mas install` may fail silently for apps with no compatible version; `brew bundle` skips failures without blocking
+
+### Manual applications (personal machines)
+
+Some apps are not available via Homebrew or the Mac App Store and must be installed manually from vendor websites. These are documented as `# Download:` comments in `Brewfile.personal`:
+
+- **Audio production platform managers** — install these first, then use them to install individual plugins (Native Access, IK Product Manager, Spitfire Audio, etc.)
+- **Standalone audio apps** — Focusrite Control, Neural DSP, KORG, VCV Rack, etc.
+
+On a new personal machine, check `Brewfile.personal` for the full list of download links after running `./install`.
 
 ### Update tmux plugins
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,7 +6,7 @@ Deferred ideas and future improvements.
 
 ## Applications
 
-- **Run `brew-audit` on personal laptop and work laptop** — Desktop audit is done (MAS apps tracked, Brewfiles updated, stale formulae cleaned). Run `brew-audit` on the remaining two machines to identify drift and reconcile.
+- **Improve `brew-audit` section 5 matching** — The /Applications matching uses caskroom directory names, which produces false positives for casks whose directory name doesn't match the app name. Could parse cask JSON metadata or use `brew info --json` (batched) for better accuracy.
 - **Document non-Homebrew app install steps** — Capture manual-install apps (vendor-specific, non-cask) as new-machine setup documentation. Audio production managers are listed in `Brewfile.personal` as comments; other categories (e.g. SketchUp, Epson drivers) need similar treatment or a RUNBOOK section.
 - **Evaluate mackup for app settings backup** — Decide whether to use mackup to backup and sync Mac app settings as part of this repo, find a better alternative, or uninstall it. Currently quarantined in Brewfile.universal but still installed.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,7 +6,8 @@ Deferred ideas and future improvements.
 
 ## Applications
 
-- **Audit installed applications** — On each primary machine (personal desktop, personal laptop, work laptop), audit `/Applications` and `~/Applications`. Sort everything into the universal/work/personal Brewfile pattern. For apps only available via the Mac App Store, either automate with the `mas` CLI or document the manual install steps.
+- **Run `brew-audit` on personal laptop and work laptop** — Desktop audit is done (MAS apps tracked, Brewfiles updated, stale formulae cleaned). Run `brew-audit` on the remaining two machines to identify drift and reconcile.
+- **Document non-Homebrew app install steps** — Capture manual-install apps (vendor-specific, non-cask) as new-machine setup documentation. Audio production managers are listed in `Brewfile.personal` as comments; other categories (e.g. SketchUp, Epson drivers) need similar treatment or a RUNBOOK section.
 
 ## Performance
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,6 +8,7 @@ Deferred ideas and future improvements.
 
 - **Run `brew-audit` on personal laptop and work laptop** — Desktop audit is done (MAS apps tracked, Brewfiles updated, stale formulae cleaned). Run `brew-audit` on the remaining two machines to identify drift and reconcile.
 - **Document non-Homebrew app install steps** — Capture manual-install apps (vendor-specific, non-cask) as new-machine setup documentation. Audio production managers are listed in `Brewfile.personal` as comments; other categories (e.g. SketchUp, Epson drivers) need similar treatment or a RUNBOOK section.
+- **Evaluate mackup for app settings backup** — Decide whether to use mackup to backup and sync Mac app settings as part of this repo, find a better alternative, or uninstall it. Currently quarantined in Brewfile.universal but still installed.
 
 ## Performance
 

--- a/packages/Brewfile.personal
+++ b/packages/Brewfile.personal
@@ -3,9 +3,6 @@
 # Sourced by install when ~/.personal marker exists
 
 # Casks
-cask "affinity-photo2"
-cask "discord"
-cask "zen"
 
 # Mac App Store
 mas "Anytune", id: 722444976
@@ -15,6 +12,7 @@ mas "Infuse", id: 1136220934
 mas "Kindle", id: 302584613
 mas "Logic Pro", id: 634148309
 mas "MainStage", id: 634159523
+mas "Panels", id: 1236567663
 mas "Paprika Recipe Manager 3", id: 1303222628
 mas "Parcel", id: 375589283
 mas "Pi Stats", id: 1514075262
@@ -32,17 +30,18 @@ mas "Unread", id: 1363637349
 # Download: UA Connect               — uaudio.com — Universal Audio (LUNA, UAD)
 
 # Audio production — standalone apps (not managed by a platform)
-# Download: Focusrite Control 2 — focusrite.com — audio interface driver/mixer
 # Download: KORG opsix native   — korg.com — FM synth
 # Download: Neural DSP          — neuraldsp.com — guitar amp sims
-# Download: RODECaster App      — rode.com — podcast/streaming mixer
 # Download: VCV Rack 2 Free     — vcvrack.com — virtual modular synth
 
 # Quarantined — delete if still commented after 6 months
+# cask "affinity-photo2"   # 20260323 - deprecated cask; manage manually
 # cask "appzapper"         # app uninstaller — 20260315
+# cask "discord"           # 20260323 - manual install as needed via Brewfile.local
 # cask "halloy"            # IRC client — 20260315
 # cask "handbrake"         # HandBrake GUI — 20260315
 # cask "openrgb"           # RGB lighting control — 20260315
 # cask "qflipper"          # Flipper Zero utility — 20260315
 # cask "signal"            # 20260315
+# cask "zen"               # 20260323
 # cask "zoom"              # 20260315

--- a/packages/Brewfile.personal
+++ b/packages/Brewfile.personal
@@ -22,6 +22,22 @@ mas "Shareful", id: 1522267256
 mas "Steam Link", id: 1246969117
 mas "Unread", id: 1363637349
 
+# Audio production — platform managers (install first, then use to install plugins)
+# Download: Arturia Software Center — arturia.com — Arturia (Pigments, V Collection)
+# Download: IK Product Manager      — ikmultimedia.com — IK (AmpliTube, MODO, T-RackS)
+# Download: iLok License Manager    — ilok.com — required by many plugin vendors
+# Download: Native Access            — native-instruments.com — NI (Kontakt, Komplete)
+# Download: Softube Central          — softube.com — Softube plugins
+# Download: Spitfire Audio           — spitfireaudio.com — Spitfire (LABS, libraries)
+# Download: UA Connect               — uaudio.com — Universal Audio (LUNA, UAD)
+
+# Audio production — standalone apps (not managed by a platform)
+# Download: Focusrite Control 2 — focusrite.com — audio interface driver/mixer
+# Download: KORG opsix native   — korg.com — FM synth
+# Download: Neural DSP          — neuraldsp.com — guitar amp sims
+# Download: RODECaster App      — rode.com — podcast/streaming mixer
+# Download: VCV Rack 2 Free     — vcvrack.com — virtual modular synth
+
 # Quarantined — delete if still commented after 6 months
 # cask "appzapper"         # app uninstaller — 20260315
 # cask "halloy"            # IRC client — 20260315

--- a/packages/Brewfile.personal
+++ b/packages/Brewfile.personal
@@ -6,6 +6,21 @@
 cask "discord"
 cask "zen"
 
+# Mac App Store
+mas "Anytune", id: 722444976
+mas "Day One", id: 1055511498
+mas "Fugue Machine Rubato", id: 6670253122
+mas "Infuse", id: 1136220934
+mas "Kindle", id: 302584613
+mas "Logic Pro", id: 634148309
+mas "MainStage", id: 634159523
+mas "Paprika Recipe Manager 3", id: 1303222628
+mas "Parcel", id: 375589283
+mas "Pi Stats", id: 1514075262
+mas "Shareful", id: 1522267256
+mas "Steam Link", id: 1246969117
+mas "Unread", id: 1363637349
+
 # Quarantined — delete if still commented after 6 months
 # cask "appzapper"         # app uninstaller — 20260315
 # cask "halloy"            # IRC client — 20260315

--- a/packages/Brewfile.personal
+++ b/packages/Brewfile.personal
@@ -3,6 +3,7 @@
 # Sourced by install when ~/.personal marker exists
 
 # Casks
+cask "affinity-photo2"
 cask "discord"
 cask "zen"
 

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -9,6 +9,7 @@ brew "zsh-history-substring-search"
 brew "zsh-fast-syntax-highlighting"
 brew "bash"
 brew "bash-completion"
+brew "docker-completion"
 
 # Theme switching
 tap "cormacrelf/tap"
@@ -105,16 +106,19 @@ cask "plexamp"
 cask "raycast"
 cask "steam"
 cask "thaw"                # menubar manager
+cask "visual-studio-code"
 cask "vivaldi"
 cask "vlc"
 
 # Mac App Store
 brew "mas"               # Mac App Store CLI
 mas "Bear", id: 1091189122
+mas "Command X", id: 6448461551
 mas "Fantastical", id: 975937182
 mas "GarageBand", id: 682658836
 mas "iMovie", id: 408981434
 mas "One Thing", id: 1604176982
+mas "Online Check", id: 6504709660
 mas "Slack", id: 803453959
 mas "Tailscale", id: 1475387142
 mas "The Unarchiver", id: 425424353

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -48,6 +48,7 @@ brew "starship"       # cross-shell prompt
 brew "thefuck"
 brew "tealdeer"
 brew "tmux"           # terminal multiplexer
+brew "watch"
 brew "wifi-password"  # display current wifi password
 brew "wtfis"
 brew "xz"
@@ -134,7 +135,6 @@ mas "Xcode", id: 497799835
 # brew "trash"                 # safer rm — 20260313
 # brew "tree"                  # 20260313
 # brew "urlview"               # tmux-urlview plugin dep — 20260313
-# brew "watch"                 # 20260313
 # cask "jordanbaird-ice"       # menu bar manager — 20260315
 # cask "keepingyouawake"       # 20260313
 # cask "pika"                  # color picker — 20260313

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -109,6 +109,18 @@ cask "vlc"
 
 # Mac App Store
 brew "mas"               # Mac App Store CLI
+mas "Bear", id: 1091189122
+mas "Fantastical", id: 975937182
+mas "GarageBand", id: 682658836
+mas "iMovie", id: 408981434
+mas "One Thing", id: 1604176982
+mas "Slack", id: 803453959
+mas "Tailscale", id: 1475387142
+mas "The Unarchiver", id: 425424353
+mas "TickTick", id: 966085870
+mas "UTC Time", id: 1538245904
+mas "Velja", id: 1607635845
+mas "Xcode", id: 497799835
 
 # Quarantined — delete if still commented after 6 months
 # brew "ack"                   # 20260313

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -99,6 +99,7 @@ cask "ghostty"
 cask "google-chrome"
 cask "iina"                # video player
 cask "imageoptim"          # image optimizer
+brew "ipcalc"
 cask "json-viewer"
 cask "latest"              # app update checker
 cask "obsidian"
@@ -134,7 +135,6 @@ mas "Xcode", id: 497799835
 # brew "handbrake"             # HandBrakeCLI — 20260315
 # brew "inetutils"             # 20260313
 # brew "iftop"                 # 20260313
-# brew "ipcalc"                # 20260313
 # brew "mackup"                # app settings backup — 20260313
 # brew "trash"                 # safer rm — 20260313
 # brew "tree"                  # 20260313

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -33,6 +33,7 @@ brew "grep"
 brew "gzip"
 brew "htop"
 brew "imagemagick"    # image processing
+brew "ipcalc"
 brew "lazydocker"     # docker TUI
 brew "lazygit"        # git TUI
 brew "mole"           # MacOS maintenance TUI
@@ -99,7 +100,6 @@ cask "ghostty"
 cask "google-chrome"
 cask "iina"                # video player
 cask "imageoptim"          # image optimizer
-brew "ipcalc"
 cask "json-viewer"
 cask "latest"              # app update checker
 cask "obsidian"

--- a/packages/Brewfile.work
+++ b/packages/Brewfile.work
@@ -32,10 +32,8 @@ cask "lens"
 
 # Quarantined — delete if still commented after 1 year
 # brew "chamber"               # SSM parameter store CLI — 20260313
-# brew "doitlive"              # terminal demo tool — 20260313
 # brew "fx"                    # json viewer — 20260313
 # brew "gnupg"                 # 20260313
-# brew "ipcalc"                # 20260323
 # brew "libpq", link: true     # 20260313
 # brew "libsndfile"            # 20260313
 # brew "puma/puma/puma-dev"    # 20260313

--- a/packages/Brewfile.work
+++ b/packages/Brewfile.work
@@ -34,6 +34,7 @@ cask "lens"
 # brew "doitlive"              # terminal demo tool — 20260313
 # brew "fx"                    # json viewer — 20260313
 # brew "gnupg"                 # 20260313
+# brew "ipcalc"                # 20260323
 # brew "libpq", link: true     # 20260313
 # brew "libsndfile"            # 20260313
 # brew "puma/puma/puma-dev"    # 20260313

--- a/packages/Brewfile.work
+++ b/packages/Brewfile.work
@@ -4,6 +4,7 @@
 
 brew "ansible"
 brew "aws-vault"
+brew "doitlive"
 brew "helm"
 brew "kubernetes-cli"
 brew "kubectx"        # switch k8s contexts


### PR DESCRIPTION
## Summary

- **MAS tracking:** Add 27 Mac App Store apps to Brewfiles (universal, personal, local) using `mas` syntax
- **Brewfile reconciliation:** Audit and reconcile all 3 machines (desktop, personal laptop, work laptop) — un-quarantine active apps, quarantine unused ones, remove stale entries
- **brew-audit script:** New `bin/brew-audit.sh` for reusable Brewfile drift detection — auto-detects machine type, reports untracked installs and missing entries
- **Audio production docs:** Document platform managers and standalone apps as download comments in Brewfile.personal
- **Doc updates:** RUNBOOK (MAS management, audit process, manual apps sections), ARCHITECTURE (MAS + vendor app notes), TODO (updated items), bootstrap (manual app reminder for personal machines)

## Test plan

- [x] Run `brew-audit` on each machine — verify sections 1-4 report accurately
- [x] Run `brew bundle check` against universal and personal/work Brewfiles
- [ ] Verify `mas list` output aligns with tracked MAS entries
- [x] Run `./install` to confirm Brewfile integration works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)