### PR TITLE
🐛 Fix brew-audit section 5 false positives for cask app matching

### DIFF
--- a/bin/brew-audit.sh
+++ b/bin/brew-audit.sh
@@ -197,23 +197,20 @@ header "Apps in /Applications not managed by Homebrew or MAS"
 count=0
 
 # Build lookup of managed app names (lowercase, no .app suffix)
-# Use Homebrew's caskroom receipts (fast, no network) + MAS names
+# Use brew JSON metadata for accurate cask→app mapping + MAS names
 managed_apps=$(
   {
-    # Cask apps: read app names from caskroom receipts
-    for cask_dir in "$(brew --prefix)"/Caskroom/*/; do
-      [[ -d "$cask_dir" ]] || continue
-      # Find .app artifacts in the latest version directory
-      latest=$(find "$cask_dir" -maxdepth 1 -mindepth 1 -type d -print 2>/dev/null | sort | tail -1)
-      latest="${latest##*/}"
-      [[ -z "$latest" ]] && continue
-      if [[ -f "$cask_dir/$latest/.metadata" ]]; then
-        # Fall back to cask name (hyphen to space, capitalize)
-        basename "$cask_dir"
-      else
-        basename "$cask_dir"
-      fi
-    done
+    # Cask apps: parse actual .app artifact names from brew metadata
+    brew info --json=v2 --installed --cask 2>/dev/null | \
+      python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for cask in data.get('casks', []):
+    for art in cask.get('artifacts', []):
+        if isinstance(art, dict) and 'app' in art:
+            for app in art['app']:
+                print(app.removesuffix('.app'))
+" 2>/dev/null
 
     # MAS apps: names from mas list
     if [[ -n "$installed_mas" ]]; then
@@ -237,12 +234,9 @@ for app_dir in /Applications ~/Applications; do
     [[ "$app" != *.app ]] && continue
     echo "$name_lower" | grep -qiE "^($skip_apps)$" && continue
 
-    # Normalize for matching: "Docker Desktop" matches cask "docker-desktop"
+    # Check if managed by cask app name or installed cask token
     name_hyphenated="${name_lower// /-}"
-
-    # Check if managed by cask name or app name
     if ! echo "$managed_apps" | grep -qixF "$name_lower" && \
-       ! echo "$managed_apps" | grep -qixF "$name_hyphenated" && \
        ! echo "$installed_casks" | grep -qixF "$name_hyphenated"; then
       finding "$name ($app_dir/)"
       ((count++)) || true

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,7 +6,6 @@ Deferred ideas and future improvements.
 
 ## Applications
 
-- **Improve `brew-audit` section 5 matching** — The /Applications matching uses caskroom directory names, which produces false positives for casks whose directory name doesn't match the app name. Could parse cask JSON metadata or use `brew info --json` (batched) for better accuracy.
 - **Document non-Homebrew app install steps** — Capture manual-install apps (vendor-specific, non-cask) as new-machine setup documentation. Audio production managers are listed in `Brewfile.personal` as comments; other categories (e.g. SketchUp, Epson drivers) need similar treatment or a RUNBOOK section.
 - **Evaluate mackup for app settings backup** — Decide whether to use mackup to backup and sync Mac app settings as part of this repo, find a better alternative, or uninstall it. Currently quarantined in Brewfile.universal but still installed.
 


### PR DESCRIPTION
## Summary
- Replace caskroom directory name scanning with `brew info --json=v2` artifact metadata to get actual `.app` names for matching
- Fixes false positives where cask tokens don't match app names (e.g. `docker-desktop`→`Docker`, `cleanshot`→`CleanShot X`, `jordanbaird-ice`→`Ice`)
- Remove completed TODO item

## Test plan
- [x] `brew-audit` runs successfully, section 5 output reviewed
- [x] Shellcheck passes (pre-commit hook)
- [x] Verify no regressions on work machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)