### PR TITLE
Document non-Homebrew manual app install steps

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -480,9 +480,12 @@ mas search "App Name"       # find an app's ID
 Some apps are not available via Homebrew or the Mac App Store and must be installed manually from vendor websites. These are documented as `# Download:` comments in `Brewfile.personal`:
 
 - **Audio production platform managers** — install these first, then use them to install individual plugins (Native Access, IK Product Manager, Spitfire Audio, etc.)
-- **Standalone audio apps** — Focusrite Control, Neural DSP, KORG, VCV Rack, etc.
+- **Standalone audio apps** — synth tutorials, amp sims, etc.
+- **Non-audio apps** — apps whose Homebrew cask is deprecated or was never available (Affinity Photo 2, Aqua Voice, etc.)
 
-On a new personal machine, check `Brewfile.personal` for the full list of download links after running `./install`.
+Machine-specific manual apps (audio interfaces, hardware utilities) go as `# Download:` comments in `Brewfile.local` on each machine.
+
+On a new personal machine, check `Brewfile.personal` and `Brewfile.local` for the full list of download links after running `./install`.
 
 ### Update tmux plugins
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -6,7 +6,6 @@ Deferred ideas and future improvements.
 
 ## Applications
 
-- **Document non-Homebrew app install steps** — Capture manual-install apps (vendor-specific, non-cask) as new-machine setup documentation. Audio production managers are listed in `Brewfile.personal` as comments; other categories (e.g. SketchUp, Epson drivers) need similar treatment or a RUNBOOK section.
 - **Evaluate mackup for app settings backup** — Decide whether to use mackup to backup and sync Mac app settings as part of this repo, find a better alternative, or uninstall it. Currently quarantined in Brewfile.universal but still installed.
 
 ## Performance

--- a/packages/Brewfile.personal
+++ b/packages/Brewfile.personal
@@ -32,10 +32,15 @@ mas "Unread", id: 1363637349
 # Audio production — standalone apps (not managed by a platform)
 # Download: KORG opsix native   — korg.com — FM synth
 # Download: Neural DSP          — neuraldsp.com — guitar amp sims
+# Download: Syntorial           — syntorial.com — synth programming tutorial
 # Download: VCV Rack 2 Free     — vcvrack.com — virtual modular synth
 
+# Non-audio — manual install (no Homebrew cask available)
+# Download: Affinity Photo 2    — affinity.serif.com — photo editor (cask deprecated)
+# Download: Aqua Voice          — withaqua.com — speech-to-text
+
+# ──────────────────────────────────────────────────────────────────
 # Quarantined — delete if still commented after 6 months
-# cask "affinity-photo2"   # 20260323 - deprecated cask; manage manually
 # cask "appzapper"         # app uninstaller — 20260315
 # cask "discord"           # 20260323 - manual install as needed via Brewfile.local
 # cask "halloy"            # IRC client — 20260315

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -129,6 +129,7 @@ mas "UTC Time", id: 1538245904
 mas "Velja", id: 1607635845
 mas "Xcode", id: 497799835
 
+# ──────────────────────────────────────────────────────────────────
 # Quarantined — delete if still commented after 6 months
 # brew "ack"                   # 20260313
 # brew "bandwhich"             # 20260313

--- a/packages/Brewfile.work
+++ b/packages/Brewfile.work
@@ -30,6 +30,7 @@ brew "eksctl"         # AWS EKS CLI
 cask "google-drive"
 cask "lens"
 
+# ──────────────────────────────────────────────────────────────────
 # Quarantined — delete if still commented after 1 year
 # brew "chamber"               # SSM parameter store CLI — 20260313
 # brew "fx"                    # json viewer — 20260313


### PR DESCRIPTION
## Summary

- Add `# Download:` entries to `Brewfile.personal` for Syntorial, Affinity Photo 2, and Aqua Voice
- Replace Affinity Photo quarantine entry with a proper `# Download:` comment (cask is deprecated)
- Expand RUNBOOK "Manual applications" section to cover non-audio apps and reference `Brewfile.local` for machine-specific manual installs
- Remove completed TODO item

## Test plan

- [ ] Verify `Brewfile.personal` comments render correctly
- [ ] Verify RUNBOOK section reads clearly

[🤖](https://claude.ai/claude-code) Generated with Claude Code