### PR TITLE
⚡ Shell startup performance audit & optimization

### DIFF
--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -36,5 +36,5 @@ github = 'zsh-users/zsh-autosuggestions'
 [plugins.zsh-history-substring-search]
 github = 'zsh-users/zsh-history-substring-search'
 
-[plugins.alias-tips]
-github = "djui/alias-tips"
+[plugins.you-should-use]
+github = "MichaelAquilina/zsh-you-should-use"

--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -33,8 +33,5 @@ use = ['{colored-man-pages,extract}/*.plugin.zsh']
 [plugins.zsh-autosuggestions]
 github = 'zsh-users/zsh-autosuggestions'
 
-[plugins.zsh-history-substring-search]
-github = 'zsh-users/zsh-history-substring-search'
-
 [plugins.you-should-use]
 github = "MichaelAquilina/zsh-you-should-use"

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -599,7 +599,7 @@ for i in 1 2 3 4 5; do /usr/bin/time -p script -q /dev/null zsh -i -c exit 2>&1 
 
 Use `script` to allocate a real PTY — sheldon and fzf key-bindings are guarded behind `[[ -t 1 ]]` and won't load in a plain `zsh -i -c exit` without a terminal, making that command an undercount. Discard the first run (cold cache). A clean startup should be under ~500ms.
 
-**Baseline (March 2026, M-series Mac):** ~320ms (warm cache). Main contributors are sheldon plugin initialization (fast-syntax-highlighting, forgit, zsh-autosuggestions) and thefuck. Revisit if it climbs above ~500ms.
+**Baseline (March 2026, M-series Mac):** ~315ms (warm cache). Main contributors are sheldon plugin initialization (fast-syntax-highlighting, forgit, zsh-autosuggestions), mise activate, and starship init. thefuck is lazy-loaded and does not contribute to startup. Revisit if it climbs above ~500ms.
 
 ---
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,10 +4,4 @@ Deferred ideas and future improvements.
 
 ---
 
-## Performance
-
-- **Shell startup time audit** — Benchmark shell startup time on all primary machines (personal desktop, personal laptop, work laptop) using the RUNBOOK method. Target is under ~500ms warm. One laptop is currently 590–690ms after the mise migration. Profile with `zsh -x` or `zprof` to identify the slowest contributors and optimize if needed. **This should be one of the last TODOs worked from this list** — let other changes land first so the audit captures the final steady-state.
-
-## Someday / Maybe
-
-- TODO: Run `brew doctor` on each machine, since if there's anything to deal with or cleanup
+_No open items._

--- a/docs/shell.cheatsheet.md
+++ b/docs/shell.cheatsheet.md
@@ -95,4 +95,4 @@ Directory stack persists for the session (up to 12 entries, no duplicates).
 - Commands starting with a space are not saved to history
 - History is shared across all open sessions in real time
 - `CTRL+R` — fuzzy history search (fzf)
-- Up/Down arrows — history substring search (matches anywhere in the command)
+- Up/Down arrows — search history matching what you've typed so far

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -5,7 +5,6 @@
 brew "zsh"
 brew "zsh-autosuggestions"
 brew "zsh-completions"
-brew "zsh-history-substring-search"
 brew "zsh-fast-syntax-highlighting"
 brew "bash"
 brew "bash-completion"

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -151,3 +151,4 @@ mas "Xcode", id: 497799835
 # cask "vscodium"              # 20260313
 # cask "flameshot"             # 20260322 - migrate to CleanShotX
 # cask "itsycal"              # 20260322 - migrate to Dot
+# brew "zsh-history-substring-search" # 20260324 — replaced by built-in up-line-or-beginning-search

--- a/zsh/lib/keybindings.zsh
+++ b/zsh/lib/keybindings.zsh
@@ -1,6 +1,9 @@
-# zsh-history-substring-search plugin binds
-bindkey '^[[A' history-substring-search-up
-bindkey '^[[B' history-substring-search-down
+# Up/Down: search history matching what's already typed (built-in, zero overhead)
+autoload -Uz up-line-or-beginning-search down-line-or-beginning-search
+zle -N up-line-or-beginning-search
+zle -N down-line-or-beginning-search
+bindkey '^[[A' up-line-or-beginning-search
+bindkey '^[[B' down-line-or-beginning-search
 
 # Restore default clear-screen (forgit can override this with git-log)
 bindkey '^L' clear-screen

--- a/zsh/zshrc.zsh
+++ b/zsh/zshrc.zsh
@@ -66,8 +66,13 @@ fi
 
 export EDITOR="vim"
 
+# Lazy-load thefuck — avoid ~150ms Python startup on every shell
 if command -v thefuck > /dev/null; then
-  eval "$(thefuck --alias)"
+  fuck() {
+    unfunction fuck
+    eval "$(thefuck --alias)"
+    fuck "$@"
+  }
 fi
 
 if [ -f $HOMEBREW_PREFIX/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]; then


### PR DESCRIPTION
## Summary

- Replace `alias-tips` with `zsh-you-should-use` (pure zsh, faster preexec hook)
- Remove `zsh-history-substring-search` — replaced with zsh built-in `up-line-or-beginning-search` (was consuming ~940ms on work laptop)
- Lazy-load `thefuck` to defer ~150ms Python startup to first use
- Clear TODO.md (all items complete), update RUNBOOK baseline

Work laptop went from ~720ms → under 500ms. Desktop baseline steady at ~315ms.

## Test plan

- [x] Benchmarked on personal desktop (~315ms)
- [x] Benchmarked on work laptop (under 500ms)
- [x] Verified `sheldon lock --update` succeeds on all machines
- [x] Verified Up/Down history search still works (built-in widget)
- [x] Verified `fuck` command works on first use (lazy-load)

[🤖](https://claude.ai/claude-code)