### PR TITLE
Add Docker CLI zsh completions

### DIFF
--- a/zsh/lib/completions.zsh
+++ b/zsh/lib/completions.zsh
@@ -17,6 +17,11 @@ if command -v kubectl &> /dev/null; then
   source <(kubectl completion zsh)
 fi
 
+# Docker completions
+if command -v docker &> /dev/null; then
+  source <(docker completion zsh)
+fi
+
 # 1Password CLI completions
 if [ -f $HOMEBREW_PREFIX/bin/op ]; then
   eval "$(op completion zsh)"; compdef _op op


### PR DESCRIPTION
## Summary
- Add dynamic Docker CLI completions to zsh, matching the existing kubectl pattern
- Guards on `docker` being in PATH before sourcing

## Test plan
- [x] Open a new shell and verify `docker <tab>` shows subcommand completions
- [ ] Verify no errors on a machine without Docker installed

[🤖](https://claude.ai/claude-code)