### PR TITLE
🐛 Guard 1Password op invocations behind TTY check

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -320,6 +320,7 @@ if [[ -f "$HOME/.work" ]]; then
   fi
 fi
 todos+=("Set up commit signing with 1Password SSH keys — see docs/RUNBOOK.md")
+todos+=("Run 'gh auth login' once so gh works in non-TTY contexts (IDE shells, scripts)")
 if [[ -f "$HOME/.env.local" ]] && ! grep -qv '^#' "$HOME/.env.local" 2>/dev/null; then
   todos+=("Add machine-specific config to ~/.env.local")
 fi

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -132,6 +132,8 @@ op read "op://VaultName/Item/field"    # read a single secret value (scriptable)
 
 **Touch ID / biometric prompts:** The `op` CLI and SSH agent trigger macOS biometric prompts (Touch ID or password) when accessing secrets. This is expected 1Password security behavior, not a bug or misconfiguration.
 
+**`gh` auth in non-TTY shells:** The `op` plugin wrapper for `gh` is guarded behind a TTY check (`[[ -t 1 ]]`) to prevent biometric popups in IDE/editor subshells. This means `gh` in non-interactive contexts uses its own stored token. Run `gh auth login` once per machine to set this up.
+
 ### Commit Signing with 1Password SSH Keys
 
 All commits are signed (`commit.gpgsign = true` in shared git config, `gpg.format = ssh`). Each machine needs its `user.signingkey` set to the SSH public key string from 1Password.

--- a/zsh/lib/completions.zsh
+++ b/zsh/lib/completions.zsh
@@ -22,8 +22,8 @@ if command -v docker &> /dev/null; then
   source <(docker completion zsh)
 fi
 
-# 1Password CLI completions
-if [ -f $HOMEBREW_PREFIX/bin/op ]; then
+# 1Password CLI completions (TTY-only — op invocation triggers biometric prompts)
+if [[ -t 1 ]] && [[ -f $HOMEBREW_PREFIX/bin/op ]]; then
   eval "$(op completion zsh)"; compdef _op op
 fi
 

--- a/zsh/lib/git.zsh
+++ b/zsh/lib/git.zsh
@@ -1,7 +1,9 @@
 # My custom git aliases and configs
 
 # Setup alias for 1password to interact with github via `gh` cli tool
-if [[ -f "${HOME}/.config/op/plugins.sh" ]]; then
+# Guarded to TTY — non-interactive shells (e.g. IDE/editor subshells) should
+# use gh's own auth token instead of triggering 1Password biometric prompts.
+if [[ -t 1 ]] && [[ -f "${HOME}/.config/op/plugins.sh" ]]; then
   source "${HOME}/.config/op/plugins.sh"
 fi
 


### PR DESCRIPTION
## Summary

Non-interactive shells (Claude desktop, IDE subshells, scripts) spawning zsh trigger macOS "op would like to access data from other apps" popups because `op` is invoked unconditionally for completions and the `gh` plugin wrapper.

- Add `[[ -t 1 ]]` TTY guard to `op` plugin sourcing in `zsh/lib/git.zsh`
- Add `[[ -t 1 ]]` TTY guard to `op completion zsh` eval in `zsh/lib/completions.zsh`
- Add `gh auth login` reminder to bootstrap TODOs
- Document TTY guard and fallback auth in RUNBOOK.md

Non-TTY contexts fall back to `gh`'s own stored OAuth token (`gh auth login`).

## Test plan

- [x] Open Claude desktop app — no "op" permission popups
- [x] Interactive terminal: `gh` still routes through 1Password (`type gh` shows the op wrapper)
- [x] Non-TTY: `zsh -c 'type gh'` shows plain `gh`, not the op wrapper

[🤖](https://claude.com/claude-code)