### PR TITLE
Add tmux-fzf-url plugin for URL fuzzy-search

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 [submodule "config/tmux/plugins/vim-tmux-navigator"]
 	path = config/tmux/plugins/vim-tmux-navigator
 	url = https://github.com/christoomey/vim-tmux-navigator
+[submodule "config/tmux/plugins/tmux-fzf-url"]
+	path = config/tmux/plugins/tmux-fzf-url
+	url = https://github.com/junegunn/tmux-fzf-url.git

--- a/config/tmux/tmux.conf
+++ b/config/tmux/tmux.conf
@@ -199,4 +199,5 @@ set -g @route_to_ping "google.com"   # DNS + routing check (Option B)
 run-shell ~/.config/tmux/plugins/tmux-open/open.tmux
 run-shell ~/.config/tmux/plugins/tmux-yank/yank.tmux
 run-shell ~/.config/tmux/plugins/extrakto/extrakto.tmux
+run-shell ~/.config/tmux/plugins/tmux-fzf-url/fzf-url.tmux
 run-shell ~/.config/tmux/plugins/vim-tmux-navigator/vim-tmux-navigator.tmux

--- a/docs/fzf.cheatsheet.md
+++ b/docs/fzf.cheatsheet.md
@@ -22,6 +22,13 @@
 
 - `preview` — open fzf with bat syntax-highlighted preview (`fzf --preview 'bat --color "always" {}'`)
 
+## tmux Integration
+
+| Key | Action |
+|-----|--------|
+| `C-a u` | Fuzzy-search URLs in current tmux pane; open or copy to clipboard (via tmux-fzf-url plugin) |
+| `C-a S` | SSH to host via fzf fuzzy picker (custom script) |
+
 ## Reference
 
 - [fzf](https://junegunn.github.io/fzf/)

--- a/docs/tldr/my-fzf.page.md
+++ b/docs/tldr/my-fzf.page.md
@@ -26,6 +26,10 @@
 
 `ssh **<TAB>`
 
+- Fuzzy-search URLs in current tmux pane (open or copy):
+
+`C-a u` (in tmux)
+
 - Open fzf with bat syntax-highlighted preview:
 
 `preview`

--- a/docs/tldr/my-tmux.page.md
+++ b/docs/tldr/my-tmux.page.md
@@ -42,6 +42,10 @@
 
 `prefix e`
 
+- Fuzzy-search URLs in current pane (open or copy):
+
+`prefix u`
+
 - Reload tmux config:
 
 `prefix r`

--- a/docs/tmux.cheatsheet.md
+++ b/docs/tmux.cheatsheet.md
@@ -67,6 +67,7 @@ Prefix key: `C-a`
 | `prefix r` | Reload tmux config |
 | `prefix R` | Refresh client |
 | `prefix ;` | Open command prompt |
+| `prefix u` | Fuzzy-search URLs in current pane (fzf popup); open or copy to clipboard |
 | `prefix S` | SSH to host via fzf fuzzy picker (opens in new window); fallback to prompt if fzf unavailable |
 | `prefix C-a` | Send prefix to nested tmux/screen session |
 
@@ -79,6 +80,7 @@ Prefix key: `C-a`
 | tmux-prefix-highlight | Status bar indicator when prefix is held or in copy mode |
 | tmux-online-status | Status bar online/offline indicator |
 | extrakto | Fuzzy-extract text from pane into prompt (with `e` key in copy mode) |
+| tmux-fzf-url | Fuzzy-search and open/copy URLs from current pane (with `prefix u`) |
 | vim-tmux-navigator | Navigate between tmux panes with Ctrl+hjkl (vim integration requires neovim plugin) |
 
 ### Plugin Updates


### PR DESCRIPTION
## Summary

- Adds [tmux-fzf-url](https://github.com/junegunn/tmux-fzf-url) as a git submodule — press `prefix u` to fuzzy-search and open/copy URLs from the current tmux pane
- Updates tmux and fzf cheatsheets and tldr pages with new keybind

## Test plan

- [ ] `tmux source ~/.config/tmux/tmux.conf` loads without errors
- [ ] `prefix u` opens fzf popup with URLs from current pane
- [ ] Selecting a URL opens it in the default browser

[🤖](https://claude.ai/claude-code)