### PR TITLE
✨ Add ~/.claude/settings.local.json stub + local file migration docs

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -234,6 +234,10 @@ create_stub "$DOTFILES_DIR/packages/Brewfile.local" \
 # cask \"example\"" \
 "packages/Brewfile.local"
 
+create_stub "$HOME/.claude/settings.local.json" \
+"{}" \
+"~/.claude/settings.local.json"
+
 # --- 9. Display type detection (macOS only) ---
 # theme-switch auto-detects per-display aspect ratios at runtime, so this
 # fallback file is only used when system_profiler is unavailable.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,10 +136,11 @@ dotfiles/
 
 - Passwords, API keys, and tokens MUST NOT be committed to version control.
 - `.gitignore` must explicitly exclude `*.local`, `.env*`, `*secrets*`, and `*.key`.
-- **Local override files** (both gitignored, sourced silently, skipped without error if absent):
+- **Local override files** (all gitignored, skipped without error if absent):
   - `~/.env.local` — machine-specific exports, PATH additions, non-secret config
   - `~/.secrets.local` — credentials, API keys, tokens
-- **Sourcing order:** `~/.env.local` first, then `~/.secrets.local` at the very end of `zshrc.zsh`.
+  - `~/.claude/settings.local.json` — machine-specific Claude Code config (deep-merged with `~/.claude/settings.json` at runtime; use for work-only integrations, local MCP servers, etc.)
+- **Sourcing order:** `~/.env.local` first, then `~/.secrets.local` at the very end of `zshrc.zsh`. Claude settings are merged by Claude Code at startup, not by the shell.
 
 ### 3.6 Editor Configuration
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -27,7 +27,7 @@ The bootstrap wizard is interactive and idempotent — it skips anything already
 - **Git identity** — copies `config/git/.gitconfig-user.example` → `.gitconfig-user` if missing. Edit this file with your name, email, and signingkey
 - **Code directories** — creates `~/code/personal/` on all machines, `~/code/work/` on work machines only
 - **Work git identity** (work machines only) — copies `config/git/.gitconfig-work.example` → `.gitconfig-work` if missing. Edit with your work name, email, and signingkey
-- **Stub files** — creates `~/.env.local`, `~/.secrets.local`, `~/.ssh/config.local`, and `packages/Brewfile.local` with commented templates if they don't exist
+- **Stub files** — creates `~/.env.local`, `~/.secrets.local`, `~/.ssh/config.local`, `~/.claude/settings.local.json`, and `packages/Brewfile.local` with commented templates if they don't exist
 - **Display type detection** (macOS) — detects ultrawide vs widescreen displays, stores fallback at `~/.local/state/display-type`
 - **Wallpapers repo** (macOS) — prompts to clone the wallpapers repo to `~/Pictures/wallpapers/` for folder-based rotation. Validates existing clones (correct remote, has images)
 - **Mise runtimes** — offers to run `mise install` to provision language toolchains
@@ -80,6 +80,25 @@ killall Dock                                                  # apply
 | `~/.env.local` | Machine-specific exports, PATH additions, non-secret config |
 | `~/.secrets.local` | API keys, tokens, credentials — never commit |
 | `~/.ssh/config.local` | Per-machine SSH host entries (not tracked) |
+| `~/.claude/settings.local.json` | Machine-specific Claude Code config (deep-merged with settings.json) |
+
+### Local files: backup & migration
+
+These untracked files contain machine-specific config that won't survive a wipe or new-machine setup. Back them up to 1Password (or your vault of choice) periodically and before migrating.
+
+| File | What to back up | Sensitive? |
+|------|----------------|-----------|
+| `~/.work` / `~/.personal` / `~/.remote*` | Just remember which marker to `touch` | No |
+| `~/.env.local` | Full file contents | Maybe |
+| `~/.secrets.local` | Full file contents | **Yes** — store in 1Password |
+| `~/.ssh/config.local` | Full file contents | Maybe |
+| `config/git/.gitconfig-user` | name, email, signingkey values | No |
+| `config/git/.gitconfig-work` | name, email, signingkey values (work machines) | No |
+| `packages/Brewfile.local` | Full file contents | No |
+| `~/.claude/settings.local.json` | Full file contents | Maybe |
+| `~/.local/state/display-type` | Single word (`widescreen` / `ultrawide`) — auto-detected, low priority | No |
+
+**Recommended workflow:** Create a secure note in 1Password called "dotfiles local config — \<machine name\>" and paste the contents of each file. Update it when you make significant changes to any local file. On a new machine, run `bootstrap.sh` first (creates stubs), then paste saved contents into each file.
 
 ---
 


### PR DESCRIPTION
Bootstrap now creates `~/.claude/settings.local.json` as an empty stub on every machine, enabling machine-specific Claude Code config (e.g., work-only telemetry integrations) that deep-merges with the shared `settings.json` at runtime.

## Summary
- **bootstrap.sh** — adds `settings.local.json` stub via existing `create_stub` helper (no-overwrite)
- **RUNBOOK.md** — new "Local files: backup & migration" section documenting all untracked files and a 1Password-based backup workflow for machine migrations
- **ARCHITECTURE.md** — adds `settings.local.json` to the local override files list

## Test plan
- [ ] Run `./bin/bootstrap.sh` — confirm `~/.claude/settings.local.json` created with `{}`
- [ ] Re-run bootstrap — confirm file not overwritten
- [ ] Start Claude Code — no errors from local settings
- [ ] Review runbook migration section

[🤖](https://claude.ai/code)