### PR TITLE
✨ Manage Raycast script commands via dotbot

### DIFF
--- a/config/raycast/scripts/quick-capture-obsidian.sh
+++ b/config/raycast/scripts/quick-capture-obsidian.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title Quick Capture to Obsidian
+# @raycast.mode silent
+# @raycast.argument1 { "type": "text", "placeholder": "Note content" }
+
+INBOX="$HOME/Documents/Obsidian/KB/Inbox/"
+DATE=$(date +%Y%m%d)
+TIME=$(date +%H-%M-%S)
+FILENAME="${DATE} ${TIME} Capture.md"
+
+cat >"$INBOX/$FILENAME" <<EOF
+---
+status: inbox
+type: note
+created: ${DATE}
+---
+# ${DATE} Capture
+
+$1
+EOF
+
+echo "Captured to Obsidian inbox"

--- a/config/raycast/scripts/script-command.template.sh
+++ b/config/raycast/scripts/script-command.template.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Raycast Script Command Template
+#
+# Duplicate this file and remove ".template." from the filename to get started.
+# See full documentation here: https://github.com/raycast/script-commands
+#
+# Required parameters:
+# @raycast.schemaVersion 1
+# @raycast.title My First Script
+# @raycast.mode fullOutput
+#
+# Optional parameters:
+# @raycast.icon 🤖
+# @raycast.packageName Raycast Scripts
+
+echo "Hello from My First Script"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -73,6 +73,8 @@ dotfiles/
     │   └── lua/
     │       ├── config/        # options, keymaps, autocmds, appearance
     │       └── plugins/       # One lazy.nvim spec per plugin concern
+    ├── raycast/              # Raycast script commands (settings synced by Raycast Premium)
+    │   └── scripts/          # Script commands dir (symlinked to ~/.config/raycast/scripts)
     ├── ripgrep/
     ├── sheldon/              # Zsh plugin manager config
     ├── ssh/                  # SSH config template (private hosts in ~/.ssh/config.local)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -60,6 +60,10 @@ Applies preferred system preferences: Dock (auto-hide, small icons, no recents),
 
 The script is idempotent and prompts before applying. It is **not** called by `./install` — run it manually on new machines. Most settings take effect immediately; input settings (key repeat, trackpad) may require logout or restart.
 
+### 6. Configure Raycast script commands (one-time)
+
+Open **Raycast Settings → Script Commands → Add Script Directory** and select `~/.config/raycast/scripts`. This points Raycast at the dotfiles-managed script commands directory.
+
 **After macOS upgrades:** Re-run the script after major upgrades (e.g. Sequoia). Major upgrades occasionally reset Dock, trackpad, and input settings. Minor updates almost never touch them. If a setting doesn't take effect after re-running, Apple likely changed or dropped the key — check `defaults read <domain>` to find the new key name.
 
 **Backup/restore:** Before running, you can snapshot current values:
@@ -193,6 +197,17 @@ Repos are organized by identity under `~/code/`:
 The `~/code/work/` directory triggers `includeIf` in git config, loading `.gitconfig-work` which overrides `user.name`, `user.email`, and `user.signingkey` for all repos cloned there. Repos anywhere else use the default personal identity from `.gitconfig-user`.
 
 Bootstrap creates these directories automatically (`~/code/work/` only on work machines).
+
+### Raycast script commands
+
+Custom [Raycast script commands](https://github.com/raycast/script-commands) live in `config/raycast/scripts/`, symlinked to `~/.config/raycast/scripts/` by dotbot. Raycast settings, keybinds, and extensions are synced by Raycast Premium — only script commands are managed here.
+
+**One-time setup:** After running `./install`, open **Raycast Settings → Script Commands → Add Script Directory** and select `~/.config/raycast/scripts`. This tells Raycast to scan that directory for script commands. You only need to do this once per machine.
+
+**Current scripts:**
+- `quick-capture-obsidian.sh` — quick-capture a note to the Obsidian inbox
+
+A `script-command.template.sh` is included as a starting point for new scripts.
 
 ### Editors
 
@@ -423,6 +438,7 @@ dotfiles/
     ├── git/                  # Git config + identity template (.gitconfig-user.example)
     ├── mise/                 # Runtime version manager config
     ├── nvim/                 # Neovim config (lazy.nvim)
+    ├── raycast/              # Raycast script commands (symlinked to ~/.config/raycast/scripts)
     ├── ripgrep/
     ├── sheldon/              # Zsh plugin manager config
     ├── ssh/                  # SSH config template (private hosts in ~/.ssh/config.local)
@@ -651,6 +667,15 @@ Drop a file in `zsh/lib/yourfile.zsh` — it will be sourced automatically next 
 ### New bin script
 
 Drop it in `bin/` — Dotbot glob-symlinks the whole directory to `~/bin`, so it's in PATH after `./install`.
+
+### New Raycast script command
+
+1. Copy `config/raycast/scripts/script-command.template.sh` to a new file in the same directory
+2. Edit the `@raycast.*` metadata comments and add your logic
+3. Make it executable: `chmod +x config/raycast/scripts/your-script.sh`
+4. Run `./install` (or it will be picked up automatically if the symlink is already in place)
+
+See the [Raycast script commands docs](https://github.com/raycast/script-commands) for the full metadata spec.
 
 ### New tealdeer custom page
 

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -89,6 +89,11 @@
     ~/.config/btop:
       path: config/btop
 
+    # Raycast
+    ~/.config/raycast/scripts:
+      path: config/raycast/scripts
+      force: true
+
     # AI tools
     ~/.claude/settings.json:
       path: config/claude/settings.json


### PR DESCRIPTION
## Summary

Track custom Raycast script commands in dotfiles while letting Raycast Premium handle settings/keybinds/extensions sync.

- Symlink `config/raycast/scripts/` → `~/.config/raycast/scripts/` via dotbot
- Includes `quick-capture-obsidian.sh` and a template for new scripts
- Documents setup (one-time Raycast directory config), usage, and how to add new scripts in RUNBOOK.md
- Adds `config/raycast/` to ARCHITECTURE.md directory tree

## Test plan

- [x] `./install` creates symlink successfully
- [x] Raycast picks up scripts after adding the directory in Settings → Script Commands
- [x] New script commands can be created from the template

[🤖](https://claude.ai/code)