### PR TITLE
✨ Add Jellyfish OTEL telemetry for Claude Code

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -702,3 +702,15 @@ cheat.sh stash        # find stash-related entries across all files
 - Both are covered by the `*.local` gitignore pattern and sourced silently at shell startup.
 - If you accidentally commit a secret: rotate it immediately, then scrub it from git history.
 - **Git identity** (`name`, `email`, `signingkey`) lives in `config/git/.gitconfig-user` — gitignored, never tracked. Copy from `config/git/.gitconfig-user.example` on each new machine.
+
+### Jellyfish OTEL telemetry (work machines)
+
+Claude Code usage telemetry is sent to Jellyfish via OTEL on work machines. Generic OTEL config (`CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_METRICS_EXPORTER`, `OTEL_EXPORTER_OTLP_PROTOCOL`) lives in `env/work.zsh` (tracked). The org-specific endpoint and bearer token must be added to `~/.secrets.local` on each work machine:
+
+```bash
+# Jellyfish OTEL — org-specific endpoint and auth
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="https://app.jellyfish.co/ingest-webhooks/claude/<org-id>"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <token>"
+```
+
+Retrieve the actual values from the 1Password item "dotfiles local config" for your machine. Claude Code inherits these env vars from the parent shell — no changes to `~/.claude/settings.json` needed.

--- a/env/work.zsh
+++ b/env/work.zsh
@@ -19,3 +19,9 @@ function avl() {
     aws-vault login -- "$@"
   fi
 }
+
+# Jellyfish OTEL telemetry for Claude Code
+# Org-specific endpoint and auth token are in ~/.secrets.local
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_PROTOCOL="http/json"


### PR DESCRIPTION
## Summary
- Add generic OTEL env vars (`CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_METRICS_EXPORTER`, `OTEL_EXPORTER_OTLP_PROTOCOL`) to `env/work.zsh` — sourced only on work machines
- Org-specific endpoint and bearer token go in `~/.secrets.local` (gitignored, per-machine) — keeps secrets out of git while leveraging the existing shell env inheritance pattern
- Document setup in runbook under Secrets Hygiene

## Test plan
- [x] Open a new shell on a work machine and verify `env | grep OTEL` shows all 5 vars
- [x] Launch `claude` and confirm telemetry flows to Jellyfish
- [x] Verify personal/remote machines are unaffected (no OTEL vars set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)