### PR TITLE
✨ Add glow with NordicPine/AlpineDawn styles and auto theme detection

### DIFF
--- a/config/glow/glow.yml
+++ b/config/glow/glow.yml
@@ -1,0 +1,10 @@
+# glow config
+# https://github.com/charmbracelet/glow
+#
+# Note: the `style` field is intentionally unset. The `glow` zsh function in
+# zsh/lib/aliases.zsh injects `-s <path>` based on ~/.local/state/appearance
+# (written by bin/theme-switch), so the correct NordicPine/AlpineDawn JSON
+# under styles/ is selected per-invocation. To override, pass `-s` yourself.
+
+pager: true
+word-wrap: 100

--- a/config/glow/styles/alpinedawn.json
+++ b/config/glow/styles/alpinedawn.json
@@ -1,0 +1,218 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "color": "#575279",
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ ",
+    "color": "#56949f",
+    "italic": true
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "#286983",
+    "bold": true
+  },
+  "h1": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "#faf4ed",
+    "background_color": "#907aa9",
+    "bold": true
+  },
+  "h2": {
+    "prefix": "## ",
+    "color": "#286983",
+    "bold": true
+  },
+  "h3": {
+    "prefix": "### ",
+    "color": "#56949f",
+    "bold": true
+  },
+  "h4": {
+    "prefix": "#### ",
+    "color": "#907aa9"
+  },
+  "h5": {
+    "prefix": "##### ",
+    "color": "#b4637a"
+  },
+  "h6": {
+    "prefix": "###### ",
+    "color": "#d7827e",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true,
+    "color": "#9893a5"
+  },
+  "emph": {
+    "italic": true,
+    "color": "#ea9d34"
+  },
+  "strong": {
+    "bold": true,
+    "color": "#b4637a"
+  },
+  "hr": {
+    "color": "#9893a5",
+    "format": "\n──────────────────────────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "#56949f",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#286983",
+    "bold": true
+  },
+  "image": {
+    "color": "#d7827e",
+    "underline": true
+  },
+  "image_text": {
+    "color": "#9893a5",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "#b4637a",
+    "background_color": "#f2e9e1"
+  },
+  "code_block": {
+    "color": "#575279",
+    "margin": 2,
+    "chroma": {
+      "text": {
+        "color": "#575279"
+      },
+      "error": {
+        "color": "#faf4ed",
+        "background_color": "#b4637a"
+      },
+      "comment": {
+        "color": "#9893a5",
+        "italic": true
+      },
+      "comment_preproc": {
+        "color": "#ea9d34"
+      },
+      "keyword": {
+        "color": "#286983",
+        "bold": true
+      },
+      "keyword_reserved": {
+        "color": "#907aa9"
+      },
+      "keyword_namespace": {
+        "color": "#b4637a"
+      },
+      "keyword_type": {
+        "color": "#56949f"
+      },
+      "operator": {
+        "color": "#b4637a"
+      },
+      "punctuation": {
+        "color": "#575279"
+      },
+      "name": {
+        "color": "#575279"
+      },
+      "name_builtin": {
+        "color": "#56949f"
+      },
+      "name_tag": {
+        "color": "#286983"
+      },
+      "name_attribute": {
+        "color": "#ea9d34"
+      },
+      "name_class": {
+        "color": "#286983",
+        "underline": true,
+        "bold": true
+      },
+      "name_constant": {
+        "color": "#907aa9"
+      },
+      "name_decorator": {
+        "color": "#ea9d34"
+      },
+      "name_exception": {
+        "color": "#b4637a"
+      },
+      "name_function": {
+        "color": "#286983"
+      },
+      "name_other": {
+        "color": "#575279"
+      },
+      "literal": {
+        "color": "#ea9d34"
+      },
+      "literal_number": {
+        "color": "#907aa9"
+      },
+      "literal_date": {
+        "color": "#ea9d34"
+      },
+      "literal_string": {
+        "color": "#ea9d34"
+      },
+      "literal_string_escape": {
+        "color": "#56949f"
+      },
+      "generic_deleted": {
+        "color": "#b4637a"
+      },
+      "generic_emph": {
+        "italic": true
+      },
+      "generic_inserted": {
+        "color": "#286983"
+      },
+      "generic_strong": {
+        "bold": true
+      },
+      "generic_subheading": {
+        "color": "#9893a5"
+      },
+      "background": {
+        "background_color": "#faf4ed"
+      }
+    }
+  },
+  "table": {
+    "center_separator": "┼",
+    "column_separator": "│",
+    "row_separator": "─"
+  },
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/config/glow/styles/nordicpine.json
+++ b/config/glow/styles/nordicpine.json
@@ -1,0 +1,218 @@
+{
+  "document": {
+    "block_prefix": "\n",
+    "block_suffix": "\n",
+    "color": "#c6e0df",
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ ",
+    "color": "#6ab4c2",
+    "italic": true
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "#38c9a7",
+    "bold": true
+  },
+  "h1": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "#0f111a",
+    "background_color": "#38c9a7",
+    "bold": true
+  },
+  "h2": {
+    "prefix": "## ",
+    "color": "#6ab4c2",
+    "bold": true
+  },
+  "h3": {
+    "prefix": "### ",
+    "color": "#087fab",
+    "bold": true
+  },
+  "h4": {
+    "prefix": "#### ",
+    "color": "#26a98b"
+  },
+  "h5": {
+    "prefix": "##### ",
+    "color": "#33859d"
+  },
+  "h6": {
+    "prefix": "###### ",
+    "color": "#cca2c0",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true,
+    "color": "#555e7a"
+  },
+  "emph": {
+    "italic": true,
+    "color": "#e6cc6f"
+  },
+  "strong": {
+    "bold": true,
+    "color": "#ffd2f8"
+  },
+  "hr": {
+    "color": "#343b51",
+    "format": "\n──────────────────────────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "#6ab4c2",
+    "underline": true
+  },
+  "link_text": {
+    "color": "#38c9a7",
+    "bold": true
+  },
+  "image": {
+    "color": "#cca2c0",
+    "underline": true
+  },
+  "image_text": {
+    "color": "#555e7a",
+    "format": "Image: {{.text}} →"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "#e6cc6f",
+    "background_color": "#232a3b"
+  },
+  "code_block": {
+    "color": "#c6e0df",
+    "margin": 2,
+    "chroma": {
+      "text": {
+        "color": "#c6e0df"
+      },
+      "error": {
+        "color": "#e4f5f4",
+        "background_color": "#bb2938"
+      },
+      "comment": {
+        "color": "#343b51",
+        "italic": true
+      },
+      "comment_preproc": {
+        "color": "#e16c58"
+      },
+      "keyword": {
+        "color": "#087fab",
+        "bold": true
+      },
+      "keyword_reserved": {
+        "color": "#cca2c0"
+      },
+      "keyword_namespace": {
+        "color": "#e16c58"
+      },
+      "keyword_type": {
+        "color": "#6ab4c2"
+      },
+      "operator": {
+        "color": "#e16c58"
+      },
+      "punctuation": {
+        "color": "#c6e0df"
+      },
+      "name": {
+        "color": "#c6e0df"
+      },
+      "name_builtin": {
+        "color": "#6ab4c2"
+      },
+      "name_tag": {
+        "color": "#087fab"
+      },
+      "name_attribute": {
+        "color": "#e6cc6f"
+      },
+      "name_class": {
+        "color": "#38c9a7",
+        "underline": true,
+        "bold": true
+      },
+      "name_constant": {
+        "color": "#ffd2f8"
+      },
+      "name_decorator": {
+        "color": "#e6cc6f"
+      },
+      "name_exception": {
+        "color": "#e16c58"
+      },
+      "name_function": {
+        "color": "#38c9a7"
+      },
+      "name_other": {
+        "color": "#c6e0df"
+      },
+      "literal": {
+        "color": "#e6cc6f"
+      },
+      "literal_number": {
+        "color": "#ffd2f8"
+      },
+      "literal_date": {
+        "color": "#ddbc44"
+      },
+      "literal_string": {
+        "color": "#e6cc6f"
+      },
+      "literal_string_escape": {
+        "color": "#ffd2f8"
+      },
+      "generic_deleted": {
+        "color": "#e16c58"
+      },
+      "generic_emph": {
+        "italic": true
+      },
+      "generic_inserted": {
+        "color": "#38c9a7"
+      },
+      "generic_strong": {
+        "bold": true
+      },
+      "generic_subheading": {
+        "color": "#555e7a"
+      },
+      "background": {
+        "background_color": "#0f111a"
+      }
+    }
+  },
+  "table": {
+    "center_separator": "┼",
+    "column_separator": "│",
+    "row_separator": "─"
+  },
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,6 +65,9 @@ dotfiles/
     │   ├── .gitconfig-user   # Local git identity (gitignored)
     │   ├── .gitconfig-work.example  # Template for work identity (copy to .gitconfig-work)
     │   └── .gitconfig-work   # Work git identity (gitignored, work machines only)
+    ├── glow/                 # Markdown renderer config + custom glamour styles
+    │   ├── glow.yml
+    │   └── styles/           # NordicPine (dark) and AlpineDawn (light) JSON
     ├── macos/                # macOS setup/defaults scripts
     ├── mise/                 # Runtime version manager config
     ├── nvim/                 # Neovim config (lazy.nvim)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -255,6 +255,7 @@ Desktop wallpaper (macOS):
 | Desktop wallpaper | Immediately (desktoppr) |
 | zsh syntax highlighting | Next prompt |
 | btop | Next launch |
+| glow | Next invocation (zsh wrapper reads `~/.local/state/appearance`) |
 
 ### Troubleshooting
 
@@ -436,6 +437,9 @@ dotfiles/
     ├── btop/
     ├── ghostty/
     ├── git/                  # Git config + identity template (.gitconfig-user.example)
+    ├── glow/                 # Markdown renderer config + custom glamour styles
+    │   ├── glow.yml
+    │   └── styles/           # NordicPine (dark) and AlpineDawn (light) JSON
     ├── mise/                 # Runtime version manager config
     ├── nvim/                 # Neovim config (lazy.nvim)
     ├── raycast/              # Raycast script commands (symlinked to ~/.config/raycast/scripts)

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -88,6 +88,9 @@
       path: config/bat/themes/rose-pine-dawn.tmTheme
     ~/.config/btop:
       path: config/btop
+    ~/.config/glow:
+      path: config/glow
+      force: true
 
     # Raycast
     ~/.config/raycast/scripts:

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -25,6 +25,7 @@ brew "fd"             # better find
 brew "ffmpeg"         # video processing
 brew "fzf"            # fuzzy finder
 brew "gawk"
+brew "glow"           # markdown renderer / pager
 brew "gnu-sed"
 brew "gnu-tar"
 brew "grep"

--- a/zsh/lib/aliases.zsh
+++ b/zsh/lib/aliases.zsh
@@ -85,6 +85,26 @@ if command -v bat > /dev/null; then
   alias bat_='bat --show-all'
 fi
 
+# glow — pick NordicPine/AlpineDawn style based on appearance state
+# (~/.local/state/appearance is written by bin/theme-switch). Glow's own
+# `style: auto` detection is unreliable in tmux/Ghostty, so we inject -s.
+# If the caller passes -s/--style explicitly, we defer to that.
+if command -v glow > /dev/null; then
+  glow() {
+    local arg
+    for arg in "$@"; do
+      case "$arg" in
+        -s|--style|--style=*) command glow "$@"; return ;;
+      esac
+    done
+    local style="$HOME/.config/glow/styles/nordicpine.json"
+    if [[ -f "$HOME/.local/state/appearance" && "$(<$HOME/.local/state/appearance)" == "light" ]]; then
+      style="$HOME/.config/glow/styles/alpinedawn.json"
+    fi
+    command glow -s "$style" "$@"
+  }
+fi
+
 # Retrain my youtube-dl muscle memory
 alias youtube-dl='echo "Use yt-dlp instead!"'
 


### PR DESCRIPTION
Adds `glow` to the universal Brewfile and wires it into the existing dark/light theme system with custom glamour styles matching the repo's NordicPine (dark) and AlpineDawn (light) palettes.

- **Brewfile** — `brew "glow"` in `packages/Brewfile.universal`
- **Custom styles** — `config/glow/styles/{nordicpine,alpinedawn}.json` map `docs/color-palettes.md` to the full glamour schema (headings, code, chroma syntax, links, tables, block quotes)
- **Config** — `config/glow/glow.yml` leaves `style:` unset so the wrapper can inject per-invocation
- **Auto theme detection** — zsh `glow()` wrapper in `zsh/lib/aliases.zsh` reads `~/.local/state/appearance` (written by `bin/theme-switch`) and injects `-s <path>`. Explicit `-s`/`--style` from the caller is passed through untouched
- **Dotbot** — symlinks `~/.config/glow` → `config/glow`
- **Docs** — glow row added to RUNBOOK response-time table and both RUNBOOK/ARCHITECTURE config trees

Rationale for the wrapper (vs. seding `glow.yml` like btop/starship): glow is one-shot so every invocation reads fresh state, no file writes needed on theme change. Comment in `aliases.zsh` documents the why.

## Test plan
- [x] `brew install glow` — already on 2.1.2
- [x] `zsh -n zsh/lib/aliases.zsh` — syntax clean
- [x] `python3 -c "json.load(...)"` on both style files — valid
- [x] `glow README.md` with state file = `light` — renders with AlpineDawn
- [x] `type glow` — resolves to wrapper function
- [x] Flip macOS appearance dark↔light and re-run `glow` to confirm live switch
- [ ] Run `./install` on a fresh checkout to confirm dotbot creates `~/.config/glow` symlink

🤖 [Generated with Claude Code](https://claude.com/claude-code)