### PR TITLE
✨ Improve new-Mac onboarding flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Includes configs for zsh, tmux, Neovim, Ghostty, Starship, and more.
 
 ### First-time setup
 
+> **New Mac?** Complete the [prerequisites](docs/RUNBOOK.md#new-mac-onboarding-prerequisites) (App Store sign-in, Apple Watch unlock, 1Password + SSH keys) before running bootstrap.
+
 ```sh
 git clone --recursive git@github.com:devnall/dotfiles.git ~/.dotfiles
 cd ~/.dotfiles
-./bin/bootstrap.sh    # Xcode CLT, Homebrew, machine-type marker, git identity, mise
+./bin/bootstrap.sh    # Xcode CLT, Homebrew, 1Password, machine-type marker, git identity, mise
 ./install             # symlinks everything, installs Brewfile packages
 ```
 

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -201,7 +201,8 @@ if [[ "$(uname)" == "Darwin" ]]; then
     info "Apple Watch unlock makes MAS installs and sudo prompts a single tap"
     info "instead of repeated password entry. Especially useful on Macs without"
     info "Touch ID (Mac Mini, Mac Studio, etc.)."
-    info "Setup: System Settings → Touch ID & Password → toggle on Apple Watch"
+    info "Setup: System Settings → 'Touch ID & Password' (or 'Login Password' on"
+    info "       Macs without Touch ID) → toggle on your Apple Watch"
     info "Prereqs: Watch paired with iPhone on the same Apple ID, 2FA enabled."
     read -rp "[→] Press Enter when ready (or skip if no Apple Watch): " _
     mkdir -p "$HOME/.local/state"

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -47,6 +47,13 @@ if [[ "$(uname)" == "Darwin" ]]; then
   fi
 fi
 
+# --- 1b. Apple Silicon advisory (macOS only) ---
+
+if [[ "$(uname)" == "Darwin" ]] && [[ "$(uname -m)" == "arm64" ]]; then
+  info "Apple Silicon detected. Some apps (e.g., Steam Link) require Rosetta 2."
+  info "Not auto-installed. Run on demand: softwareupdate --install-rosetta --agree-to-license"
+fi
+
 # --- 2. Submodule check ---
 
 if [[ -d "$DOTFILES_DIR/dotbot" ]] && [[ -z "$(ls -A "$DOTFILES_DIR/dotbot" 2>/dev/null)" ]]; then
@@ -120,6 +127,97 @@ if [[ "$(uname)" == "Darwin" ]] || [[ -f "$HOME/.remote-full" ]]; then
     else
       warn "Skipped Homebrew install — you can install it later"
     fi
+  fi
+fi
+
+# --- 4a. 1Password setup (macOS only) ---
+# Cask wraps the official direct-download installer (full functionality:
+# SSH agent, browser integration, biometric unlock). MAS build is more
+# sandboxed and lacks features.
+
+p1_ssh_ok=false
+github_ssh_check() {
+  # ssh -T returns 1 even on successful auth; check stderr for the success message.
+  # || true swallows ssh's exit code so pipefail doesn't mask the grep result.
+  local output
+  output=$(ssh -o BatchMode=yes -o ConnectTimeout=5 -T git@github.com 2>&1 || true)
+  printf '%s' "$output" | grep -q "successfully authenticated"
+}
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  if [[ -d "/Applications/1Password.app" ]]; then
+    skip "1Password app"
+  elif command -v brew &>/dev/null; then
+    read -rp "[→] Install 1Password app? [Y/n]: " yn
+    if [[ "$yn" =~ ^[Nn]$ ]]; then
+      warn "Skipped 1Password app — install before using SSH agent for git"
+    else
+      info "Installing 1Password..."
+      brew install --cask 1password
+      success "1Password installed"
+    fi
+  else
+    warn "Homebrew not available — install 1Password from 1password.com manually"
+  fi
+
+  if command -v op &>/dev/null; then
+    skip "1Password CLI (op)"
+  elif command -v brew &>/dev/null; then
+    info "Installing 1Password CLI..."
+    brew install --cask 1password-cli
+    success "1Password CLI installed"
+  fi
+
+  if github_ssh_check; then
+    skip "1Password SSH agent → GitHub"
+    p1_ssh_ok=true
+  else
+    info "1Password SSH agent setup:"
+    info "  1. Open 1Password and sign in"
+    info "  2. Settings → Developer → enable 'Use the SSH agent'"
+    info "  3. Add your SSH key item to 1Password if not already present"
+    info "  4. Upload the public key to GitHub: https://github.com/settings/keys"
+    info "     Add it as BOTH an Authentication key AND a Signing key"
+    read -rp "[→] Press Enter when done (or skip with Ctrl-C): " _
+    if github_ssh_check; then
+      success "GitHub SSH auth verified"
+      p1_ssh_ok=true
+    else
+      warn "Could not verify GitHub SSH auth — fix before pushing or signing commits"
+    fi
+  fi
+fi
+
+# --- 4b. Apple Watch unlock advisory (macOS only) ---
+
+if [[ "$(uname)" == "Darwin" ]]; then
+  if [[ -f "$HOME/.local/state/apple-watch-prompted" ]]; then
+    skip "Apple Watch unlock advisory"
+  else
+    info "Apple Watch unlock makes MAS installs and sudo prompts a single tap"
+    info "instead of repeated password entry. Especially useful on Macs without"
+    info "Touch ID (Mac Mini, Mac Studio, etc.)."
+    info "Setup: System Settings → Touch ID & Password → toggle on Apple Watch"
+    info "Prereqs: Watch paired with iPhone on the same Apple ID, 2FA enabled."
+    read -rp "[→] Press Enter when ready (or skip if no Apple Watch): " _
+    mkdir -p "$HOME/.local/state"
+    touch "$HOME/.local/state/apple-watch-prompted"
+  fi
+fi
+
+# --- 4c. App Store sign-in gate (macOS personal/work only) ---
+
+if [[ "$(uname)" == "Darwin" ]] && { [[ -f "$HOME/.personal" ]] || [[ -f "$HOME/.work" ]]; }; then
+  if [[ -f "$HOME/.local/state/appstore-signin-prompted" ]]; then
+    skip "App Store sign-in gate"
+  else
+    warn "Sign into the App Store BEFORE continuing — otherwise every 'mas install'"
+    warn "will re-prompt for your Apple ID password from scratch."
+    info "Once signed in, expect a Touch ID / Apple Watch tap per app and possibly"
+    info "a one-time TOS or family-sharing confirmation. Not silent, but no loop."
+    read -rp "[→] Press Enter when signed in (or Ctrl-C to abort): " _
+    mkdir -p "$HOME/.local/state"
+    touch "$HOME/.local/state/appstore-signin-prompted"
   fi
 fi
 
@@ -366,7 +464,9 @@ if [[ -f "$HOME/.work" ]]; then
     todos+=("Edit config/git/.gitconfig-work with your work name, email, and signingkey")
   fi
 fi
-todos+=("Set up commit signing with 1Password SSH keys — see docs/RUNBOOK.md")
+if [[ "$p1_ssh_ok" != "true" ]]; then
+  todos+=("Set up commit signing with 1Password SSH keys — see docs/RUNBOOK.md")
+fi
 todos+=("Run 'gh auth login' once so gh works in non-TTY contexts (IDE shells, scripts)")
 if [[ -f "$HOME/.env.local" ]] && ! grep -qv '^#' "$HOME/.env.local" 2>/dev/null; then
   todos+=("Add machine-specific config to ~/.env.local")

--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -174,10 +174,14 @@ if [[ "$(uname)" == "Darwin" ]]; then
   else
     info "1Password SSH agent setup:"
     info "  1. Open 1Password and sign in"
-    info "  2. Settings → Developer → enable 'Use the SSH agent'"
-    info "  3. Add your SSH key item to 1Password if not already present"
-    info "  4. Upload the public key to GitHub: https://github.com/settings/keys"
-    info "     Add it as BOTH an Authentication key AND a Signing key"
+    info "  2. Settings → Developer → click 'Set Up SSH Agent...'"
+    info "     (1Password will offer to edit ~/.ssh/config — accept)"
+    info "  3. Existing SSH keys in any 1Password vault are auto-discovered."
+    info "     No need to generate a new key if you already have one stored."
+    info "     Verify with: ssh-add -L  (should list your keys)"
+    info "  4. Copy your SSH public key from its key item in 1Password"
+    info "  5. Upload to GitHub: https://github.com/settings/keys"
+    info "     Add it TWICE: once as Authentication Key, once as Signing Key"
     read -rp "[→] Press Enter when done (or skip with Ctrl-C): " _
     if github_ssh_check; then
       success "GitHub SSH auth verified"

--- a/config/git/config
+++ b/config/git/config
@@ -60,7 +60,7 @@
   log = true
   conflictstyle = zdiff3
 [url "git@github.com:"]
-  insteadOf = https://github.com/
+  pushInsteadOf = https://github.com/
   insteadOf = "gh:"
   pushInsteadOf = "github:"
   pushInsteadOf = "git://github.com"

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -129,10 +129,6 @@ Applies preferred system preferences: Dock (auto-hide, small icons, no recents),
 
 The script is idempotent and prompts before applying. It is **not** called by `./install` — run it manually on new machines. Most settings take effect immediately; input settings (key repeat, trackpad) may require logout or restart.
 
-### 6. Configure Raycast script commands (one-time)
-
-Open **Raycast Settings → Extensions → Script Commands → Add Script Directory** and select `~/.config/raycast/scripts`. This points Raycast at the dotfiles-managed script commands directory.
-
 **After macOS upgrades:** Re-run the script after major upgrades (e.g. Sequoia). Major upgrades occasionally reset Dock, trackpad, and input settings. Minor updates almost never touch them. If a setting doesn't take effect after re-running, Apple likely changed or dropped the key — check `defaults read <domain>` to find the new key name.
 
 **Backup/restore:** Before running, you can snapshot current values:
@@ -142,6 +138,10 @@ defaults export com.apple.dock /tmp/dock-backup.plist       # backup
 defaults import com.apple.dock /tmp/dock-backup.plist        # restore
 killall Dock                                                  # apply
 ```
+
+### 6. Configure Raycast script commands (one-time)
+
+Open **Raycast Settings → Extensions → Script Commands → Add Script Directory** and select `~/.config/raycast/scripts`. This points Raycast at the dotfiles-managed script commands directory.
 
 ### Quick reference
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -131,7 +131,7 @@ The script is idempotent and prompts before applying. It is **not** called by `.
 
 ### 6. Configure Raycast script commands (one-time)
 
-Open **Raycast Settings → Script Commands → Add Script Directory** and select `~/.config/raycast/scripts`. This points Raycast at the dotfiles-managed script commands directory.
+Open **Raycast Settings → Extensions → Script Commands → Add Script Directory** and select `~/.config/raycast/scripts`. This points Raycast at the dotfiles-managed script commands directory.
 
 **After macOS upgrades:** Re-run the script after major upgrades (e.g. Sequoia). Major upgrades occasionally reset Dock, trackpad, and input settings. Minor updates almost never touch them. If a setting doesn't take effect after re-running, Apple likely changed or dropped the key — check `defaults read <domain>` to find the new key name.
 
@@ -271,7 +271,7 @@ Bootstrap creates these directories automatically (`~/code/work/` only on work m
 
 Custom [Raycast script commands](https://github.com/raycast/script-commands) live in `config/raycast/scripts/`, symlinked to `~/.config/raycast/scripts/` by dotbot. Raycast settings, keybinds, and extensions are synced by Raycast Premium — only script commands are managed here.
 
-**One-time setup:** After running `./install`, open **Raycast Settings → Script Commands → Add Script Directory** and select `~/.config/raycast/scripts`. This tells Raycast to scan that directory for script commands. You only need to do this once per machine.
+**One-time setup:** After running `./install`, open **Raycast Settings → Extensions → Script Commands → Add Script Directory** and select `~/.config/raycast/scripts`. This tells Raycast to scan that directory for script commands. You only need to do this once per machine.
 
 **Current scripts:**
 - `quick-capture-obsidian.sh` — quick-capture a note to the Obsidian inbox

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -18,7 +18,7 @@ Complete these steps **before** cloning the repo and running `bootstrap.sh`. The
 
 If you have an Apple Watch and your Mac doesn't have built-in Touch ID (Mac Mini, Mac Studio, iMac without Magic Keyboard with Touch ID), set up Watch-approves-Mac unlock:
 
-- `System Settings → Touch ID & Password → Apple Watch` → toggle on.
+- `System Settings → "Touch ID & Password"` (or `"Login Password"` on Macs without Touch ID like the Mac Mini) → toggle on your Apple Watch.
 - Prereqs: Watch paired with iPhone on the same Apple ID, two-factor authentication enabled.
 
 This turns every MAS install authentication and sudo prompt into a single Watch tap instead of typing your password.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -42,10 +42,16 @@ Bootstrap will warn if missing. Required for git, compilers, and most dev tools.
 Bootstrap will install the app and CLI via Homebrew if you haven't already. Either way, you need to:
 
 - Sign into 1Password.
-- Enable SSH agent: `Settings → Developer → Use the SSH agent`.
-- Make sure your SSH key item exists in 1Password (or sync it down from another vault).
-- Upload the public key to GitHub at https://github.com/settings/keys — add it **twice**: once as an Authentication Key, once as a Signing Key.
-- Verify:
+- **Settings → Developer → click "Set Up SSH Agent..."**. 1Password will offer to write/modify `~/.ssh/config` — accept. (The dotfiles repo already includes an `IdentityAgent` directive in `config/ssh/config`; 1Password's edits are compatible and necessary to activate the agent.)
+- **Existing SSH keys in any 1Password vault are auto-discovered** by the agent. No need to generate a new key if you already have one stored. To verify the agent picked them up:
+  ```sh
+  ssh-add -L
+  # should list your public keys
+  ```
+- Only if you don't have an SSH key in 1Password yet: create one via 1Password → **New Item → SSH Key → Generate**.
+- Copy the public key from its key item in 1Password (there's a "Copy Public Key" action).
+- Upload to GitHub at https://github.com/settings/keys — add it **twice**: once as an Authentication Key, once as a Signing Key.
+- Verify end-to-end:
   ```sh
   ssh -T git@github.com
   # Hi <username>! You've successfully authenticated, but GitHub does not provide shell access.

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -4,6 +4,69 @@ Detailed reference for setting up, using, and maintaining these dotfiles.
 
 ---
 
+## New Mac onboarding (prerequisites)
+
+Complete these steps **before** cloning the repo and running `bootstrap.sh`. The bootstrap wizard handles 1Password, App Store, and Apple Watch as gates, but the manual macOS-side actions (signing in, enabling features) still need to happen — bootstrap pauses for you, it doesn't click for you.
+
+### 1. macOS first-run
+
+- Sign into iCloud with your Apple ID.
+- Run Software Update (`System Settings → General → Software Update`) — get to the latest minor version before installing tools.
+- Connect to network.
+
+### 2. Apple Watch unlock (if applicable)
+
+If you have an Apple Watch and your Mac doesn't have built-in Touch ID (Mac Mini, Mac Studio, iMac without Magic Keyboard with Touch ID), set up Watch-approves-Mac unlock:
+
+- `System Settings → Touch ID & Password → Apple Watch` → toggle on.
+- Prereqs: Watch paired with iPhone on the same Apple ID, two-factor authentication enabled.
+
+This turns every MAS install authentication and sudo prompt into a single Watch tap instead of typing your password.
+
+### 3. App Store sign-in
+
+Open the App Store and sign in with your Apple ID. **Do this before running bootstrap.** Otherwise every `mas install` re-prompts for your password from scratch — a dozen+ prompts for a personal Brewfile.
+
+MAS app associations are account-level, so apps obtained on prior Macs are recognized here. With Apple Watch unlock or Touch ID set up, installs are a tap each. Without either, you'll be typing your password per app.
+
+### 4. Xcode Command Line Tools
+
+```sh
+xcode-select --install
+```
+
+Bootstrap will warn if missing. Required for git, compilers, and most dev tools.
+
+### 5. 1Password setup
+
+Bootstrap will install the app and CLI via Homebrew if you haven't already. Either way, you need to:
+
+- Sign into 1Password.
+- Enable SSH agent: `Settings → Developer → Use the SSH agent`.
+- Make sure your SSH key item exists in 1Password (or sync it down from another vault).
+- Upload the public key to GitHub at https://github.com/settings/keys — add it **twice**: once as an Authentication Key, once as a Signing Key.
+- Verify:
+  ```sh
+  ssh -T git@github.com
+  # Hi <username>! You've successfully authenticated, but GitHub does not provide shell access.
+  ```
+
+See [Commit Signing with 1Password SSH Keys](#commit-signing-with-1password-ssh-keys) for the per-machine signing key configuration that follows.
+
+**Why Homebrew cask vs Mac App Store for 1Password:** the cask wraps the official direct-download installer (full functionality — SSH agent, browser integration, biometric unlock). The MAS build is more sandboxed and historically had reduced features. 1Password's in-app updater handles updates independently of `brew upgrade`.
+
+### 6. Apple Silicon note
+
+Rosetta 2 is **not** installed by default and is **not** auto-installed by bootstrap. Some apps (Steam Link, certain audio plugins, older vendor tools) require it. Install on demand:
+
+```sh
+softwareupdate --install-rosetta --agree-to-license
+```
+
+Steam Link specifically has been removed from `Brewfile.personal` for this reason — see the `# Download:` comment there for the manual install link.
+
+---
+
 ## New Machine Setup
 
 ### 1. Clone the repo

--- a/packages/Brewfile.personal
+++ b/packages/Brewfile.personal
@@ -18,7 +18,6 @@ mas "Paprika Recipe Manager 3", id: 1303222628
 mas "Parcel", id: 375589283
 mas "Pi Stats", id: 1514075262
 mas "Shareful", id: 1522267256
-mas "Steam Link", id: 1246969117
 mas "Unread", id: 1363637349
 
 # Audio production — platform managers (install first, then use to install plugins)
@@ -39,6 +38,7 @@ mas "Unread", id: 1363637349
 # Non-audio — manual install (no Homebrew cask available)
 # Download: Affinity Photo 2    — affinity.serif.com — photo editor (cask deprecated)
 # Download: Aqua Voice          — withaqua.com — speech-to-text
+# Download: Steam Link          — apps.apple.com/app/id1246969117 — requires Rosetta 2 on Apple Silicon (softwareupdate --install-rosetta --agree-to-license)
 
 # ──────────────────────────────────────────────────────────────────
 # Quarantined — delete if still commented after 6 months


### PR DESCRIPTION
Onboarding a brand-new personal Mac surfaced four chicken-and-egg failures in the bootstrap → `./install` flow. This rewires the gitconfig to make HTTPS reads work without SSH, adds bootstrap phases that gate on the macOS-side prerequisites we'd been silently expecting, and removes a Brewfile entry that requires Rosetta.

## Summary

- **gitconfig**: switch `insteadOf https://github.com/` → `pushInsteadOf`. Reads stay HTTPS (no SSH dependency); pushes still go SSH (signing/auth preserved). Fixes `brew tap cormacrelf/tap` and similar HTTPS-fetch failures on fresh machines before 1Password is set up.
- **bootstrap.sh**: new phases for 1Password app + CLI install, Apple Watch unlock advisory, App Store sign-in gate, and Apple Silicon Rosetta advisory. Idempotent via `~/.local/state/*-prompted` markers; the "set up commit signing" TODO drops when GitHub SSH auth already works.
- **Brewfile.personal**: remove `mas "Steam Link"` (x86_64-only, requires Rosetta). Replaced with a manual `# Download:` comment.
- **Docs**: new "New Mac onboarding (prerequisites)" section in `docs/RUNBOOK.md` covering iCloud, App Store, Apple Watch, Xcode CLT, 1Password, and Rosetta. README quick-start links to it.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] `git config --get-all url.git@github.com:.pushInsteadOf` → 3 entries; `insteadOf` → only `gh:`
- [x] `git ls-remote https://github.com/Homebrew/homebrew-core HEAD` succeeds via HTTPS without SSH
- [x] `brew bundle check --file=packages/Brewfile.personal` no longer references Steam Link
- [x] `bash -n bin/bootstrap.sh` and `shellcheck bin/bootstrap.sh` both clean
- [ ] End-to-end clean-machine validation — deferred to next new-Mac setup (can't manufacture)

[🤖](https://claude.com/claude-code)