### PR TITLE
maint/unmanage-claude-settings-via-dotbot

### DIFF
--- a/config/claude/settings.json
+++ b/config/claude/settings.json
@@ -51,7 +51,8 @@
     "command": "bash ~/.claude/statusline-command.sh"
   },
   "enabledPlugins": {
-    "frontend-design@claude-plugins-official": true
+    "frontend-design@claude-plugins-official": true,
+    "example-skills@anthropic-agent-skills": true
   },
   "extraKnownMarketplaces": {
     "claude-code-plugins": {
@@ -59,6 +60,14 @@
         "source": "github",
         "repo": "anthropics/claude-code"
       }
+    },
+    "anthropic-agent-skills": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/skills"
+      }
     }
-  }
+  },
+  "effortLevel": "high",
+  "theme": "light"
 }

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -98,9 +98,6 @@
       force: true
 
     # AI tools
-    ~/.claude/settings.json:
-      path: config/claude/settings.json
-      force: true
     ~/.claude/statusline-command.sh:
       path: config/claude/statusline-command.sh
       force: true


### PR DESCRIPTION
Claude Code writes to `settings.json` frequently (plugins, permissions, effortLevel, theme, etc.), which made dotbot ownership a constant source of conflicts and symlink churn and caused issues with the work account's Jellyfish integration.

Removed the `~/.claude/settings.json` symlink entry from `install.config.yaml` and replaced the live symlink with a real file. The repo copy of `config/claude/settings.json` remains as a reference snapshot but is no longer authoritative.

[🤖](https://claude.ai/claude-code)