### PR TITLE
✨ Add linux-bat-install helper for remote bat upgrades

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # Dotfiles Project Spec
 
 > **Version:** 5.0
-> **Purpose:** Architecture reference and task plan for the `~/.dotfiles` repo. Part A documents design decisions and constraints. Part B holds the current project's task plan (rotates per project).
+> **Purpose:** Architecture reference and task plan for the `~/.dotfiles` repo. Part A documents design decisions and constraints. Part B holds the **latest** project's task plan — in progress, or the most recently completed. It is overwritten by the next project's first commit, never reset to an idle state on its own (completed plans stay recoverable from this file's git history).
 >
 > **Repo:** `~/.dotfiles` (Dotbot-managed, macOS/zsh-centric, with Linux remote support)
 >
@@ -34,8 +34,6 @@ After all cleanup work is complete, these must all be true:
 ## Part B: Task Plan
 
 ### Project: Remote bat version upgrade helper
-
-> **Previous:** v4.0 Dotbot deep audit & optimization — completed. Install pipeline cleaned, config reorganized, RUNBOOK docs added.
 
 **Problem**
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -33,6 +33,75 @@ After all cleanup work is complete, these must all be true:
 
 ## Part B: Task Plan
 
-_No active project. Replace this section with the next task plan._
+### Project: Remote bat version upgrade helper
 
 > **Previous:** v4.0 Dotbot deep audit & optimization — completed. Install pipeline cleaned, config reorganized, RUNBOOK docs added.
+
+**Problem**
+
+`config/bat/config` uses options introduced in bat **0.25.0** that hard-error on
+older versions:
+
+- `--theme="auto:system"`, `--theme-light`, `--theme-dark` (light/dark auto-switching)
+- `--squeeze-limit`
+- `--set-terminal-title`
+
+The config is symlinked universally by dotbot. On `.remote` (minimal, no Homebrew)
+Debian/Ubuntu servers, apt ships bat **0.24.0**, so every `bat` invocation fails on
+unknown flags. Manual fix to date: `apt remove` bat, then install the current
+release `.deb` from `sharkdp/bat` via `dpkg`.
+
+**Scope / context**
+
+- Only `.remote` machines are affected. `.remote-full` (Homebrew) and macOS already
+  run a current bat (0.26.1+).
+- On Debian/Ubuntu the apt package installs the binary as **`batcat`**, not `bat`
+  (conflict with `bacula-console-bat`). The repo's aliases and fzf previews all call
+  `bat`, so the apt package is doubly wrong. The sharkdp `.deb` installs as `bat`,
+  fixing both the version and the naming gap.
+
+**Decisions (made 2026-06-13)**
+
+- **Delivery:** standalone idempotent `bin/linux-bat-install` (auto-symlinked to
+  `~/bin` via the existing `bin/*` glob) + RUNBOOK docs. Not wired into `./install`
+  (avoids sudo prompts mid-install) or relied on via `bootstrap.sh` (the documented
+  remote flow doesn't run bootstrap).
+- **Version:** resolve the **latest** `sharkdp/bat` release at run time; only act
+  when installed bat is below a 0.25.0 floor.
+
+**Tasks**
+
+- [x] Create `bin/linux-bat-install`:
+  - [x] No-op (exit 0) unless on Linux with `dpkg` available.
+  - [x] No-op if `bat --version` is already ≥ 0.25.0 (leaves brew bat alone;
+        idempotent re-runs). Checks the `bat`-named binary specifically so an apt
+        `batcat` still triggers the upstream install (fixes the naming gap too).
+  - [x] Detect arch via `dpkg --print-architecture` (amd64 / arm64 / armhf; warn +
+        exit on anything else).
+  - [x] Resolve the latest release tag from the
+        `https://github.com/sharkdp/bat/releases/latest` redirect (`curl -fsSLI`,
+        no jq).
+  - [x] Download `bat_<ver>_<arch>.deb` to a temp dir (trap-cleaned).
+  - [x] If the apt package is present (`dpkg -s bat`), `sudo apt-get remove -y bat`.
+  - [x] `sudo dpkg -i` the `.deb` (falls back to `apt-get -f install -y` for deps);
+        temp dir cleaned on exit.
+  - [x] Use the info/success/warn output style from `bin/bootstrap.sh`.
+  - [x] Keep shellcheck-clean (bin/ is in the pre-commit shellcheck scope).
+- [x] Document in `docs/RUNBOOK.md` → Remote/Server Setup: note apt's bat is too old
+      for the shared config and point to `linux-bat-install` in the "Optional
+      nice-to-haves" area; added a row to the "What you get" table.
+- [x] Mention `bin/linux-bat-install` in `docs/ARCHITECTURE.md` (§3.2
+      optional-tool-guards note).
+
+**Status:** Implemented on branch `feat/remote-bat-upgrade`. Verified on macOS:
+shellcheck + `bash -n` clean, platform guard no-ops, `version_ge` correct across
+cases, latest-release resolution returns v0.26.1 with a live 200 on the amd64 asset.
+Not yet run on a real Debian/Ubuntu `.remote` box (no access from here).
+
+**Acceptance**
+
+- On a `.remote` Debian/Ubuntu box, `linux-bat-install` upgrades bat to the current
+  release, `bat` (not `batcat`) resolves, and `config/bat/config` loads with no
+  errors.
+- Re-running the script is a clean no-op.
+- macOS and `.remote-full` machines are unaffected (version floor short-circuits).

--- a/bin/linux-bat-install
+++ b/bin/linux-bat-install
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+#
+# linux-bat-install — install/upgrade bat from the latest sharkdp/bat release.
+#
+# Why: config/bat/config uses options added in bat 0.25.0 (--theme="auto:system",
+# --theme-light/-dark, --squeeze-limit, --set-terminal-title). Debian/Ubuntu's apt
+# ships bat 0.24.0, which hard-errors on those flags, and installs the binary as
+# `batcat` rather than `bat` (conflict with bacula-console-bat). The repo's aliases
+# and fzf previews all call `bat`. This script swaps the apt package for the upstream
+# .deb, fixing both the version and the naming gap.
+#
+# Idempotent and self-guarding:
+#   - No-op unless on Linux with dpkg available (macOS/.remote-full use Homebrew).
+#   - No-op if a `bat`-named binary is already >= 0.25.0 (Homebrew, or a prior run).
+#
+# Run on demand on a minimal `.remote` server:
+#   linux-bat-install
+
+set -euo pipefail
+
+MIN_VERSION="0.25.0"   # config feature floor — below this, bat errors on our config
+
+# --- Output helpers (match bin/bootstrap.sh style) ---
+
+if command -v tput >/dev/null 2>&1; then
+  BOLD=$(tput bold); GREEN=$(tput setaf 2); YELLOW=$(tput setaf 3); RED=$(tput setaf 1); RESET=$(tput sgr0)
+else
+  BOLD="" GREEN="" YELLOW="" RED="" RESET=""
+fi
+
+info()    { printf '%s[→]%s %s\n' "$BOLD"   "$RESET" "$1"; }
+success() { printf '%s[✓]%s %s\n' "$GREEN"  "$RESET" "$1"; }
+warn()    { printf '%s[!]%s %s\n' "$YELLOW" "$RESET" "$1"; }
+error()   { printf '%s[✗]%s %s\n' "$RED"    "$RESET" "$1" >&2; }
+
+# --- Helpers ---
+
+# True (0) if version $1 >= version $2.
+version_ge() {
+  [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+}
+
+# Version of the `bat`-named binary specifically (empty/nonzero if absent).
+# We check `bat`, not `batcat`: an apt `batcat` doesn't satisfy our config, which
+# invokes `bat`, so the upstream .deb is still wanted to provide that name.
+bat_bin_version() {
+  command -v bat >/dev/null 2>&1 || return 1
+  bat --version 2>/dev/null | awk '{print $2; exit}'
+}
+
+# --- 1. Platform guard ---
+
+if [ "$(uname -s)" != "Linux" ]; then
+  info "Not Linux — bat is managed by Homebrew here. Nothing to do."
+  exit 0
+fi
+
+if ! command -v dpkg >/dev/null 2>&1; then
+  warn "dpkg not found — this script targets Debian/Ubuntu only."
+  warn "Install bat from your package manager or https://github.com/sharkdp/bat/releases"
+  exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  error "curl is required but not installed."
+  exit 1
+fi
+
+# --- 2. Skip if a current bat is already present ---
+
+current="$(bat_bin_version || true)"
+if [ -n "$current" ] && version_ge "$current" "$MIN_VERSION"; then
+  success "bat $current already installed (>= $MIN_VERSION) — nothing to do."
+  exit 0
+fi
+
+if [ -n "$current" ]; then
+  info "Found bat $current (< $MIN_VERSION) — upgrading."
+else
+  info "No 'bat' binary found — installing the latest release."
+fi
+
+# --- 3. Resolve privilege escalation (need root for apt-get / dpkg) ---
+
+SUDO=""
+if [ "$(id -u)" -ne 0 ]; then
+  if command -v sudo >/dev/null 2>&1; then
+    SUDO="sudo"
+  else
+    error "Root required (apt-get remove / dpkg -i) but sudo is unavailable. Re-run as root."
+    exit 1
+  fi
+fi
+
+priv() {
+  if [ -n "$SUDO" ]; then sudo "$@"; else "$@"; fi
+}
+
+# --- 4. Map architecture to a release asset ---
+
+dpkg_arch="$(dpkg --print-architecture)"
+case "$dpkg_arch" in
+  amd64) asset_arch="amd64" ;;
+  arm64) asset_arch="arm64" ;;
+  armhf) asset_arch="armhf" ;;
+  *)
+    error "Unsupported architecture: $dpkg_arch"
+    error "Grab a .deb manually from https://github.com/sharkdp/bat/releases"
+    exit 1
+    ;;
+esac
+
+# --- 5. Resolve the latest release version (no jq; follow the redirect) ---
+
+info "Resolving latest sharkdp/bat release..."
+final_url="$(curl -fsSLI -o /dev/null -w '%{url_effective}' \
+  https://github.com/sharkdp/bat/releases/latest)"
+tag="${final_url##*/}"          # e.g. v0.26.1
+version="${tag#v}"              # e.g. 0.26.1
+
+if [ -z "$version" ] || [ "$tag" = "latest" ]; then
+  error "Could not resolve the latest bat version from GitHub."
+  exit 1
+fi
+
+deb="bat_${version}_${asset_arch}.deb"
+url="https://github.com/sharkdp/bat/releases/download/${tag}/${deb}"
+
+# --- 6. Download ---
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+info "Downloading $deb ..."
+if ! curl -fSL -o "$tmpdir/$deb" "$url"; then
+  error "Download failed: $url"
+  exit 1
+fi
+
+# --- 7. Remove the apt package (if present) and install the upstream .deb ---
+
+if dpkg -s bat >/dev/null 2>&1; then
+  info "Removing apt 'bat' package (it installs as 'batcat')..."
+  priv apt-get remove -y bat
+fi
+
+info "Installing $deb ..."
+priv dpkg -i "$tmpdir/$deb" || priv apt-get -f install -y
+
+# --- 8. Verify ---
+
+new="$(bat_bin_version || true)"
+if [ -n "$new" ] && version_ge "$new" "$MIN_VERSION"; then
+  success "bat $new installed."
+else
+  warn "Install finished but 'bat' isn't on PATH as expected — open a new shell or check /usr/bin/bat."
+fi

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,6 +109,7 @@ dotfiles/
 - **Plugin manager:** Sheldon (`config/sheldon/`) manages zsh plugins. Homebrew dependency. Initialization guarded with `command -v sheldon > /dev/null && [[ -t 1 ]]`.
 - **Terminal font:** `SauceCodePro Nerd Font Mono` is installed via `Brewfile.universal` (`font-sauce-code-pro-nerd-font` cask). Required by Ghostty config and Starship prompt glyphs. Remote machines don't need it — the local terminal renders all glyphs.
 - **Optional tool guards:** Tools that may not be installed on all machines (zoxide, thefuck, terraform, bat) are guarded with `command -v` checks. The installer's `bat cache --build` step is similarly guarded.
+- **Remote bat upgrade:** Debian/Ubuntu apt ships bat 0.24.0, which errors on the shared `config/bat/config` (it uses 0.25.0+ options) and installs the binary as `batcat`. `bin/linux-bat-install` is an idempotent, self-guarding helper that swaps the apt package for the latest upstream `.deb` on minimal `.remote` servers. Run on demand — not wired into `./install`. No-op on macOS and `.remote-full` (Homebrew bat).
 
 ### 3.3 Machine-Specific PATH
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -411,6 +411,7 @@ This creates all symlinks. Homebrew and Brewfile steps are skipped.
 | starship prompt | skips if not installed; falls back to system prompt |
 | zoxide, thefuck, terraform completions | skip if not installed (guarded with `command -v`) |
 | bat theme cache | skips if bat not installed |
+| bat (Debian/Ubuntu) | apt's 0.24.0 errors on the shared config — run `linux-bat-install` (see below) |
 | Homebrew PATH | harmless on Linux (`/usr/local` typically exists) |
 | Brewfile installs | skipped via `~/.remote` guard |
 
@@ -426,6 +427,23 @@ git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf && ~/.fzf/install
 # zoxide — smarter cd
 curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
 ```
+
+### bat (Debian/Ubuntu)
+
+apt ships an old bat (0.24.0 on current Debian/Ubuntu) that **errors on the shared
+`config/bat/config`** — it uses options added in bat 0.25.0 (`--theme="auto:system"`,
+`--theme-light`/`--theme-dark`, `--squeeze-limit`, `--set-terminal-title`). The apt
+package also installs the binary as `batcat`, not `bat`, which the repo's aliases and
+fzf previews expect. Run the helper to swap it for the latest upstream `.deb`:
+
+```sh
+linux-bat-install    # symlinked to ~/bin by ./install
+```
+
+It's idempotent and self-guarding: a no-op on macOS, on `.remote-full` (Homebrew bat),
+or if a `bat` ≥ 0.25.0 is already installed. It resolves the latest `sharkdp/bat`
+release, removes the apt package if present, and installs the matching `.deb` (needs
+`sudo`). Not part of `./install` — run it on demand on minimal `.remote` servers.
 
 ---
 


### PR DESCRIPTION
Automates the manual bat upgrade I've been doing on the remote server.

apt ships bat **0.24.0** on Debian/Ubuntu, which hard-errors on the shared `config/bat/config` (it uses 0.25.0+ options: `--theme="auto:system"`, `--theme-light`/`--theme-dark`, `--squeeze-limit`, `--set-terminal-title`) and installs the binary as `batcat`, not `bat`. The repo's aliases and fzf previews all call `bat`.

## What this adds

- **`bin/linux-bat-install`** — swaps the apt package for the latest upstream `.deb` on minimal `.remote` servers. Auto-symlinked to `~/bin` via the existing `bin/*` glob (no `install.config.yaml` change).
  - No-op unless Linux + `dpkg`; no-op if a `bat`-named binary ≥ 0.25.0 already exists (Homebrew on `.remote-full`, prior runs).
  - Checks the `bat`-named binary specifically, so an apt `batcat` still triggers the install — fixing the naming gap too.
  - Resolves the latest `sharkdp/bat` release via the `/releases/latest` redirect (no jq), detects arch (amd64/arm64/armhf), removes the apt package if present, `dpkg -i` (deps fallback to `apt-get -f install`).
- **Docs:** RUNBOOK gets a "bat (Debian/Ubuntu)" subsection + a "What you get" table row; ARCHITECTURE §3.2 gets a note; SPEC.md captures the task plan.

## Verification (macOS)

- shellcheck + `bash -n` clean; full `pre-commit` suite passes
- platform guard no-ops cleanly; `version_ge` correct across cases (incl. `0.9.0 < 0.25.0`)
- live release resolution → v0.26.1, amd64 asset returns HTTP 200

**Not yet run on a real Debian/Ubuntu box** — no access from here. That's the one remaining acceptance item.

🤖 [Generated with Claude Code](https://claude.com/claude-code)