### PR TITLE
🐛 Harden terminal handling for unknown TERM over SSH

### DIFF
--- a/bin/bootstrap.sh
+++ b/bin/bootstrap.sh
@@ -14,7 +14,9 @@ DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 # --- Output helpers (match dotbot style) ---
 
-tput_available() { command -v tput >/dev/null 2>&1; }
+# Require that tput actually works for $TERM, not just that it's installed —
+# an unknown terminal (e.g. xterm-ghostty over SSH) makes tput exit non-zero.
+tput_available() { command -v tput >/dev/null 2>&1 && tput sgr0 >/dev/null 2>&1; }
 
 if tput_available; then
   BOLD=$(tput bold)

--- a/bin/linux-bat-install
+++ b/bin/linux-bat-install
@@ -22,7 +22,10 @@ MIN_VERSION="0.25.0"   # config feature floor — below this, bat errors on our 
 
 # --- Output helpers (match bin/bootstrap.sh style) ---
 
-if command -v tput >/dev/null 2>&1; then
+# Probe that tput works for the current $TERM, not just that it exists — an
+# unknown terminal (e.g. xterm-ghostty on a server without that terminfo) makes
+# tput exit non-zero, which under `set -e` would abort the script.
+if command -v tput >/dev/null 2>&1 && tput sgr0 >/dev/null 2>&1; then
   BOLD=$(tput bold); GREEN=$(tput setaf 2); YELLOW=$(tput setaf 3); RED=$(tput setaf 1); RESET=$(tput sgr0)
 else
   BOLD="" GREEN="" YELLOW="" RED="" RESET=""

--- a/config/bash/bashrc
+++ b/config/bash/bashrc
@@ -4,6 +4,16 @@
 ##########
 
 ##########
+# TERM fallback
+##########
+# Downgrade to a generic TERM when the current value has no terminfo entry on
+# this host (e.g. xterm-ghostty forwarded over SSH to a server without it).
+# Prevents broken backspace/keys and tput errors. No-op where the entry exists.
+if [ -n "$TERM" ] && command -v infocmp >/dev/null 2>&1 && ! infocmp "$TERM" >/dev/null 2>&1; then
+	export TERM=xterm-256color
+fi
+
+##########
 # Aliases
 ##########
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -445,6 +445,21 @@ or if a `bat` ≥ 0.25.0 is already installed. It resolves the latest `sharkdp/b
 release, removes the apt package if present, and installs the matching `.deb` (needs
 `sudo`). Not part of `./install` — run it on demand on minimal `.remote` servers.
 
+### Broken backspace / `tput: unknown terminal` over SSH
+
+Ghostty (and kitty, etc.) set `TERM=xterm-ghostty`, which SSH forwards to the server.
+If that server has no matching terminfo entry, backspace and other keys misbehave and
+`tput` errors out. The zsh entrypoint and the bash baseline self-heal this: if `$TERM`
+has no terminfo entry on the host, they fall back to `xterm-256color` before keybindings
+initialize. A no-op where the entry exists (e.g. macOS).
+
+For full-fidelity keys on a server you use often, install Ghostty's terminfo once from
+your **local** machine instead of relying on the downgrade:
+
+```sh
+infocmp -x xterm-ghostty | ssh you@server -- tic -x -
+```
+
 ---
 
 ## Troubleshooting `./install`

--- a/zsh/zshrc.zsh
+++ b/zsh/zshrc.zsh
@@ -5,6 +5,14 @@
 : "${XDG_CONFIG_HOME:=$HOME/.config}"
 : "${XDG_DATA_HOME:=$HOME/.local/share}"
 
+# Fall back to a generic TERM when the current value has no terminfo entry on
+# this host — e.g. TERM=xterm-ghostty forwarded over SSH to a server that lacks
+# Ghostty's terminfo. Without this, backspace/keys and tput break. Must run
+# before zle/keybindings init. No-op where the terminfo entry exists (e.g. macOS).
+if [[ -n "$TERM" ]] && command -v infocmp >/dev/null 2>&1 && ! infocmp "$TERM" >/dev/null 2>&1; then
+  export TERM=xterm-256color
+fi
+
 # HOMEBREW_PREFIX, PATH, MANPATH, INFOPATH are set by brew shellenv in zprofile.
 # Fallback for non-login shells where zprofile didn't run.
 if [ -z "$HOMEBREW_PREFIX" ]; then


### PR DESCRIPTION
Surfaced while testing `linux-bat-install` on a `.remote` Ubuntu box from Ghostty: the script crashed with `tput: unknown terminal "xterm-ghostty"` and backspace stopped working.

## Root cause

Ghostty sets `TERM=xterm-ghostty`; SSH forwards it to servers that lack that terminfo entry. Two failures follow:

1. **`tput` aborts the script.** `bin/linux-bat-install` (and `bin/bootstrap.sh`) guarded color setup only on *"does tput exist."* On an unknown terminal `tput` exits non-zero, and under `set -euo pipefail` that killed the script before the no-op check ever ran (confirmed: exit 3, the exact error reported).
2. **Backspace/keys break** because zle reads the wrong terminfo for an unknown `$TERM`.

## Fix

- **`bin/linux-bat-install`, `bin/bootstrap.sh`** — probe that `tput sgr0` actually works, not just that `tput` is installed. The probe sits in an `if` condition (exempt from `set -e`), so an unknown terminal falls back to no-color instead of aborting.
- **`zsh/zshrc.zsh`, `config/bash/bashrc`** — if `$TERM` has no terminfo entry on the host, downgrade to `xterm-256color` *before* keybindings/zle init. Self-healing and a no-op where the entry exists (e.g. macOS with Ghostty's terminfo), so it never clobbers a properly-configured box.
- **`docs/RUNBOOK.md`** — troubleshooting note covering the fallback and the higher-fidelity alternative (`infocmp -x xterm-ghostty | ssh you@server -- tic -x -`).

## Verification

- `pre-commit` (shellcheck + `zsh -n`) passes; `bash -n` clean on bashrc
- Simulated `TERM=xterm-ghostty-doesnotexist`: old guard aborts (exit 3), new probe survives with no-color
- Fallback logic downgrades only unknown terminals; leaves `xterm-256color`/`tmux-256color` untouched

🤖 [Generated with Claude Code](https://claude.com/claude-code)