### PR TITLE
Fix re-install downgrade + add work-machine gh GITHUB_TOKEN unset alias

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -109,7 +109,7 @@ The bootstrap wizard is interactive and idempotent — it skips anything already
 
 This will:
 - Create all symlinks (zshrc, nvim, tmux, ghostty, starship, bat, btop, etc.)
-- Run `brew bundle` for `Brewfile.universal`, plus `Brewfile.work` or `Brewfile.personal` based on the marker file, plus `Brewfile.local` if it exists
+- Run `brew bundle --no-upgrade` for `Brewfile.universal`, plus `Brewfile.work` or `Brewfile.personal` based on the marker file, plus `Brewfile.local` if it exists. `--no-upgrade` keeps `./install` install-only so self-updating apps (Chrome, Vivaldi, etc.) aren't downgraded to the cask version on re-run; use `bubu` / `brew upgrade` for intentional upgrades
 
 ### 4. Install runtimes
 

--- a/env/work.zsh
+++ b/env/work.zsh
@@ -25,3 +25,9 @@ function avl() {
 export CLAUDE_CODE_ENABLE_TELEMETRY=1
 export OTEL_METRICS_EXPORTER=otlp
 export OTEL_EXPORTER_OTLP_PROTOCOL="http/json"
+
+# Unset $GITHUB_TOKEN per-invocation so `gh auth login` and friends use the
+# keychain credential instead of erroring on the work-provided token.
+if command -v gh > /dev/null; then
+  alias gh="env GITHUB_TOKEN='' gh"
+fi

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -128,20 +128,23 @@
     -
      command: 'command -v brew > /dev/null || { echo "⚠ Homebrew not found. Run ./bin/bootstrap.sh first or install manually."; }'
      description: Verify Homebrew is available
+    # --no-upgrade keeps ./install idempotent: missing packages install, but
+    # already-installed casks/MAS apps that have self-updated past the cask
+    # version stay put. Use `brew upgrade` for intentional upgrades.
     -
-     command: '([[ "$(uname)" == "Darwin" ]] || [[ -f ~/.remote-full ]]) && brew bundle --file=packages/Brewfile.universal || true'
+     command: '([[ "$(uname)" == "Darwin" ]] || [[ -f ~/.remote-full ]]) && brew bundle --no-upgrade --file=packages/Brewfile.universal || true'
      description: Install universal Homebrew packages
      stdout: true
     -
-     command: '[[ -f ~/.work ]] && brew bundle --file=packages/Brewfile.work || true'
+     command: '[[ -f ~/.work ]] && brew bundle --no-upgrade --file=packages/Brewfile.work || true'
      description: Install work Homebrew packages
      stdout: true
     -
-     command: '[[ -f ~/.personal ]] && brew bundle --file=packages/Brewfile.personal || true'
+     command: '[[ -f ~/.personal ]] && brew bundle --no-upgrade --file=packages/Brewfile.personal || true'
      description: Install personal Homebrew packages
      stdout: true
     -
-     command: '[[ -f packages/Brewfile.local ]] && brew bundle --file=packages/Brewfile.local || true'
+     command: '[[ -f packages/Brewfile.local ]] && brew bundle --no-upgrade --file=packages/Brewfile.local || true'
      description: Install local Homebrew packages
      stdout: true
     -


### PR DESCRIPTION
## Summary
- Add a work-machine `gh` alias (`env GITHUB_TOKEN='' gh`) so `gh auth login` and friends use the keychain credential instead of the work-provided `$GITHUB_TOKEN`. Lives in `env/work.zsh` so it only loads on machines with the `~/.work` marker, and guards on `command -v gh`.
- Pass `--no-upgrade` to all `brew bundle` invocations in `install.config.yaml` so `./install` stops reinstalling self-updating casks (Chrome, Vivaldi, etc.) at their older cask-pinned version. Intentional upgrades go through `bubu` / `brew upgrade`, which already skips `auto_updates` casks by default.
- Update `docs/RUNBOOK.md` to reflect the new install-only behavior.

## Test plan
- [x] On a work machine: open a new shell, confirm `alias gh` shows the wrapper, and `gh auth status` resolves via keychain rather than `$GITHUB_TOKEN`
- [x] On a non-work machine: confirm the alias does NOT load (no `~/.work` marker)
- [x] Run `./install` with Chrome/Vivaldi already self-updated past their cask versions; confirm they are not reinstalled/downgraded
- [x] Run `./install` with a brand-new Brewfile entry; confirm it installs as expected
- [ ] Run `brew upgrade` and confirm self-updating casks are skipped (no `--greedy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)