### PR TITLE
✨ Track Claude Code custom commands via Dotbot

### DIFF
--- a/config/claude/commands/janitor.md
+++ b/config/claude/commands/janitor.md
@@ -1,0 +1,1 @@
+Post-merge local repo cleanup. Capture the current branch name, switch to main, pull latest, and delete the old local branch. If already on main, just pull. Do not push or fetch --prune — just the three-step local cleanup. Do this without asking for confirmation.

--- a/config/claude/commands/shipit.md
+++ b/config/claude/commands/shipit.md
@@ -1,0 +1,1 @@
+Commit, push, and open a PR for the current branch. Do all three without asking for confirmation between steps. Follow the repo's commit and PR conventions (gitmoji prefixes, CLAUDE.md rules). If already on main, warn and stop — never commit directly to main.

--- a/config/claude/commands/wrap-up.md
+++ b/config/claude/commands/wrap-up.md
@@ -1,0 +1,9 @@
+Perform a wrap-up review of the current work before moving on. Check each of the following and report findings concisely:
+
+1. **Uncommitted changes** — Run `git status` and `git diff`. Flag anything unstaged or uncommitted.
+2. **Stale TODOs** — Read the project's TODO file (if one exists) and check for items that are now outdated, completed, or contradicted by work on the current branch. Also check for new TODOs that should be added based on decisions made during the session.
+3. **Doc drift** — If docs like ARCHITECTURE.md, RUNBOOK.md, or README.md exist, scan them for references to things changed on the current branch (renamed files, removed features, new tools, changed conventions). Flag anything that looks stale.
+4. **Memory worth saving** — Review the conversation for user preferences, corrections, project context, or reference information that would be valuable in future sessions but isn't already saved. Propose specific memories (don't save without confirmation).
+5. **Context hygiene** — If the conversation context is heavy, suggest `/compact` or `/clear`.
+
+Format the output as a checklist with findings under each item. If everything is clean for a category, say so in one line. Be direct — skip categories with nothing to report.

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -101,6 +101,9 @@
     ~/.claude/statusline-command.sh:
       path: config/claude/statusline-command.sh
       force: true
+    ~/.claude/commands:
+      path: config/claude/commands
+      force: true
 
     # Wallpapers
     ~/.local/share/wallpapers:


### PR DESCRIPTION
## What

Track my three custom Claude Code slash commands in the repo and symlink them into `~/.claude/`, so they sync to my other Macs via the normal `git pull && ./install` flow.

- `wrap-up` — end-of-work review checklist (uncommitted changes, stale TODOs, doc drift, memory, context hygiene)
- `janitor` — post-merge local cleanup (switch to main, pull, delete old branch)
- `shipit` — commit + push + open PR for the current branch

## How

- Files added under `config/claude/commands/`
- Dotbot link entry: `~/.claude/commands` → `config/claude/commands` (`force: true`, matching `statusline-command.sh`)
- A directory symlink means any new command created in `~/.claude/commands/` auto-tracks in the repo going forward

## Apply on other machines

```sh
cd ~/.dotfiles && git pull && ./install --only link
```

Note: `force: true` replaces an existing real `~/.claude/commands` dir with the symlink — fine here since these are the only custom commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)