### PR TITLE
📝 Add --no-upgrade to documented brew bundle upgrade recipe

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -627,10 +627,12 @@ Dotbot's `relink: true` (the default in this repo) removes stale symlinks and re
 ### Update Homebrew packages
 
 ```sh
-bubu  # brew update && brew upgrade
-brew bundle --file=~/.dotfiles/packages/Brewfile.universal
+bubu  # brew update && brew upgrade — upgrades formulae and non-greedy casks
+brew bundle --no-upgrade --file=~/.dotfiles/packages/Brewfile.universal
 # plus Brewfile.work or Brewfile.personal as appropriate
 ```
+
+`bubu` handles actual upgrades. `brew bundle --no-upgrade` only installs any new Brewfile entries — `--no-upgrade` avoids downgrading self-updating casks (Chrome, Vivaldi, etc.) to the cask's pinned version.
 
 ### Check for Brewfile drift
 


### PR DESCRIPTION
## Summary
- Update the **Update Homebrew packages** section in `docs/RUNBOOK.md` so the documented upgrade workflow matches the install workflow established in #58.
- Bare `brew bundle` could downgrade self-updating casks (Chrome, Vivaldi, etc.) on a fresh-enough cask formula. `bubu` already performs intentional upgrades for formulae and non-greedy casks; the bundle call's only remaining job is installing newly-added entries — `--no-upgrade` is the right default.
- Added a one-line clarification explaining the split of responsibilities between `bubu` and `brew bundle --no-upgrade`.

## Test plan
- [ ] Skim the rendered diff for the **Update Homebrew packages** section
- [ ] Confirm the recipe still installs missing Brewfile entries (`brew bundle --no-upgrade` adds-but-doesn't-touch-existing)
- [ ] Confirm `bubu` still upgrades formulae and non-greedy casks as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)