### PR TITLE
🔧 Add AddKeysToAgent and UseKeychain to universal SSH Host * block

### DIFF
--- a/config/ssh/config
+++ b/config/ssh/config
@@ -6,4 +6,6 @@
 Include ~/.ssh/config.local
 
 Host *
+  AddKeysToAgent yes
+  UseKeychain yes
   IdentityAgent "~/.1p-agent.sock"


### PR DESCRIPTION
## Summary

Adds two universal, non-sensitive macOS SSH niceties to the tracked `config/ssh/config` `Host *` block:

- `AddKeysToAgent yes`
- `UseKeychain yes`

These were extracted from a batch of machine-specific config that had been pasted directly into the tracked file. The machine-specific portions — CallRail jump hosts, private IPs, internal hostname globs, and a default `User` — have been moved to the untracked `~/.ssh/config.local` per the runbook (`docs/RUNBOOK.md` → SSH config). Only these two universal flags remain to be shared.

## Verification

- `git diff` against committed shows exactly the two added lines.
- `ssh -G git@github.com` still resolves user `git` with the 1Password agent intact — commit signing/auth unaffected.
- Machine-specific hosts continue to resolve correctly via `~/.ssh/config.local`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)