### PR TITLE
✨ Add rsync to universal Brewfile

### DIFF
--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -41,6 +41,7 @@ brew "nmap"
 brew "prettyping"
 brew "reattach-to-user-namespace"
 brew "ripgrep"        # better grep
+brew "rsync"          # macOS ships ancient 2.6.9; this is current 3.x
 brew "rustscan"       # portscanner
 brew "sheldon"        # zsh plugin manager
 brew "shfmt"          # shell script formatter


### PR DESCRIPTION
Adds `rsync` to `Brewfile.universal` so every machine gets a current build instead of the ancient version macOS ships.

- macOS's `/usr/bin/rsync` is `openrsync`, reporting as "2.6.9 compatible" — that protocol dates to 2006 and lacks zstd compression, `--info=progress2`, modern `--delete` semantics, and many flags scripts assume today.
- Homebrew's formula is 3.4.4 (protocol 32). Installed to `/opt/homebrew/bin`, which precedes `/usr/bin` on PATH, so it takes over with no alias or shim.
- Placed alphabetically in the Core CLI utilities block (between `ripgrep` and `rustscan`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)