### PR TITLE
Codify Mac Studio rebuild gaps: Brewfile apps, macOS defaults, RUNBOOK

### DIFF
--- a/config/macos/defaults.sh
+++ b/config/macos/defaults.sh
@@ -40,7 +40,7 @@ setting() { printf '    %s\n' "$1"; }
 # --- Confirmation prompt ---
 
 printf '\n%s=== macOS defaults ===%s\n\n' "$BOLD" "$RESET"
-info "This will apply system preferences for: Dock, Finder, Input, Screenshots, Mission Control, System UI"
+info "This will apply system preferences for: Dock, Finder, Input, Text & Typing, Screenshots, Mission Control, System UI, Save dialogs & Files"
 printf '\n'
 read -rp "Apply macOS defaults? [y/N] " confirm
 if [[ "$confirm" != [yY] ]]; then
@@ -70,6 +70,16 @@ setting "Use genie minimize animation"
 
 defaults write com.apple.dock show-recents -bool false
 setting "Hide recent apps section"
+
+defaults write com.apple.dock autohide-delay -float 0
+setting "No delay before the Dock auto-shows"
+
+defaults write com.apple.dock minimize-to-application -bool true
+setting "Minimize windows into the app icon"
+
+defaults write com.apple.dock magnification -bool true
+defaults write com.apple.dock largesize -int 128
+setting "Enable Dock magnification (128px)"
 
 printf '\n'
 read -rp "  Remove all default Dock icons? (You can re-add apps later) [y/N] " wipe_dock
@@ -109,6 +119,22 @@ setting "Search current folder by default"
 defaults write com.apple.finder FXEnableExtensionChangeWarning -bool false
 setting "Disable extension change warning"
 
+defaults write com.apple.finder _FXShowPosixPathInTitle -bool true
+setting "Show full POSIX path in window title"
+
+defaults write com.apple.finder _FXSortFoldersFirst -bool true
+setting "Keep folders on top when sorting"
+
+defaults write com.apple.finder QuitMenuItem -bool true
+setting "Allow quitting Finder with ⌘Q"
+
+defaults write com.apple.finder FXRemoveOldTrashItems -bool true
+setting "Remove items from Trash after 30 days"
+
+defaults write com.apple.finder NewWindowTarget -string "PfLo"
+defaults write com.apple.finder NewWindowTargetPath -string "file://${HOME}/Downloads/"
+setting "Open new Finder windows in ~/Downloads"
+
 success "Finder configured"
 
 # =============================================================================
@@ -124,6 +150,9 @@ setting "  Fast key repeat rate"
 defaults write NSGlobalDomain InitialKeyRepeat -int 15
 setting "  Short delay before repeat (~225ms)"
 
+defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false
+setting "  Repeat key on hold (no accent menu)"
+
 setting "Trackpad:"
 defaults write com.apple.AppleMultitouchTrackpad Clicking -bool true
 setting "  Enable tap-to-click"
@@ -134,9 +163,39 @@ setting "  Enable tap-to-click at login screen"
 defaults write com.apple.AppleMultitouchTrackpad TrackpadThreeFingerDrag -bool true
 setting "  Enable three-finger drag"
 
+defaults write com.apple.AppleMultitouchTrackpad TrackpadRightClick -bool true
+setting "  Enable two-finger right-click"
+
+setting "Scrolling:"
+defaults write NSGlobalDomain com.apple.swipescrolldirection -bool false
+setting "  Disable natural scroll direction"
+
 defaults write com.apple.accessibility ReduceMotionEnabled -int 0 2>/dev/null || true
 
 success "Input configured (logout/restart may be needed)"
+
+# =============================================================================
+# Text & Typing
+# =============================================================================
+
+info "Configuring Text & Typing…"
+
+defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false
+setting "Disable auto-capitalization"
+
+defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
+setting "Disable autocorrect"
+
+defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
+setting "Disable smart dashes"
+
+defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false
+setting "Disable period substitution on double-space"
+
+defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
+setting "Disable smart quotes"
+
+success "Text & Typing configured"
 
 # =============================================================================
 # Screenshots
@@ -184,6 +243,10 @@ success "Mission Control configured"
 
 info "Configuring System UI…"
 
+setting "Appearance:"
+defaults write NSGlobalDomain AppleInterfaceStyleSwitchesAutomatically -bool true
+setting "  Auto-switch Light/Dark with time of day"
+
 setting "Battery:"
 defaults write com.apple.controlcenter BatteryShowPercentage -bool false
 setting "  Hide battery percentage in menu bar"
@@ -191,6 +254,9 @@ setting "  Hide battery percentage in menu bar"
 setting "Clock:"
 defaults write com.apple.menuextra.clock Show24Hour -int 1
 setting "  Use 24-hour clock"
+
+defaults write NSGlobalDomain AppleICUForce24HourTime -bool true
+setting "  Force 24-hour time system-wide"
 
 defaults write com.apple.menuextra.clock ShowDate -int 2
 setting "  Hide date"
@@ -207,6 +273,30 @@ setting "  Don't show seconds"
 success "System UI configured"
 
 # =============================================================================
+# Save Dialogs & Files
+# =============================================================================
+
+info "Configuring Save dialogs & file behavior…"
+
+defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode -bool true
+defaults write NSGlobalDomain NSNavPanelExpandedStateForSaveMode2 -bool true
+setting "Expand the Save panel by default"
+
+defaults write NSGlobalDomain NSDocumentSaveNewDocumentsToCloud -bool false
+setting "Save new documents to disk (not iCloud) by default"
+
+defaults write com.apple.desktopservices DSDontWriteNetworkStores -bool true
+setting "Don't write .DS_Store on network shares (NAS)"
+
+defaults write com.apple.desktopservices DSDontWriteUSBStores -bool true
+setting "Don't write .DS_Store on USB volumes"
+
+defaults write com.apple.TimeMachine DoNotOfferNewDisksForBackup -bool true
+setting "Don't prompt to use new disks for Time Machine"
+
+success "Save dialogs & files configured"
+
+# =============================================================================
 # Apply changes
 # =============================================================================
 
@@ -217,4 +307,4 @@ killall Dock Finder SystemUIServer 2>/dev/null || true
 
 printf '\n'
 success "macOS defaults applied!"
-warn "Some input settings (key repeat, trackpad) may require logout or restart."
+warn "Some settings (key repeat, trackpad, text substitutions, appearance, .DS_Store-on-network) may require logout or restart."

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -125,7 +125,7 @@ Installs all tools defined in `~/.config/mise/config.toml` (go, lua, node, pytho
 bash config/macos/defaults.sh
 ```
 
-Applies preferred system preferences: Dock (auto-hide, small icons, no recents), Finder (list view, show hidden files, extensions), keyboard repeat rate, tap-to-click, three-finger drag, screenshot location (`~/Pictures/Screenshots`), Mission Control (no hot corners, stable Spaces), and menu bar clock (24-hour, no date).
+Applies preferred system preferences: Dock (auto-hide with no delay, small icons, magnification, no recents, minimize-into-icon), Finder (list view, hidden files, extensions, POSIX path in title, folders-first, ⌘Q to quit, 30-day trash, new windows → `~/Downloads`), Input (fast key repeat, key-repeat-on-hold, tap-to-click, three-finger drag, two-finger right-click, natural-scroll off), Text & Typing (disable autocorrect + smart quotes/dashes/period/capitalization), screenshot location (`~/Pictures/Screenshots`), Mission Control (no hot corners, stable Spaces), System UI (auto Light/Dark, 24-hour clock, no date), and Save & Files (expanded save panels, save-to-disk default, **no `.DS_Store` on network/USB shares**, no Time Machine new-disk prompt).
 
 The script is idempotent and prompts before applying. It is **not** called by `./install` — run it manually on new machines. Most settings take effect immediately; input settings (key repeat, trackpad) may require logout or restart.
 
@@ -172,6 +172,8 @@ These untracked files contain machine-specific config that won't survive a wipe 
 | `~/.local/state/display-type` | Single word (`widescreen` / `ultrawide`) — auto-detected, low priority | No |
 
 **Recommended workflow:** Create a secure note in 1Password called "dotfiles local config — \<machine name\>" and paste the contents of each file. Update it when you make significant changes to any local file. On a new machine, run `bootstrap.sh` first (creates stubs), then paste saved contents into each file.
+
+**Before a wipe or migration — audit `Brewfile.local`.** Its entries are gitignored and *not* codified, so they will **not** reinstall from the repo — easy to forget, since installed apps look identical to codified ones. Triage each entry: promote anything you want on more than one machine to a tracked Brewfile (`Brewfile.universal` / `Brewfile.personal`); keep genuinely machine-specific tools (hardware drivers, this-box-only apps) in `Brewfile.local` and stash the curated file per the workflow above; drop the rest. The same "is this worth keeping?" pass applies to `~/.ssh/config.local` host entries. Verify your commit-signing SSH key is actually present in your 1Password vault (`ssh-keygen -lf ~/.ssh/id_rsa.pub` and match the fingerprint) — the signing config is useless if the key itself isn't recoverable.
 
 ---
 

--- a/packages/Brewfile.personal
+++ b/packages/Brewfile.personal
@@ -3,6 +3,7 @@
 # Sourced by install when ~/.personal marker exists
 
 # Casks
+cask "antinote"          # quick scratchpad notes
 cask "zoom"
 
 # Mac App Store
@@ -13,6 +14,7 @@ mas "Infuse", id: 1136220934
 mas "Kindle", id: 302584613
 mas "Logic Pro", id: 634148309
 mas "MainStage", id: 634159523
+mas "Marked 2", id: 890031187
 mas "Panels", id: 1236567663
 mas "Paprika Recipe Manager 3", id: 1303222628
 mas "Parcel", id: 375589283
@@ -35,10 +37,8 @@ mas "Unread", id: 1363637349
 # Download: Syntorial           — syntorial.com — synth programming tutorial
 # Download: VCV Rack 2 Free     — vcvrack.com — virtual modular synth
 
-# Non-audio — manual install (no Homebrew cask available)
-# Download: Affinity Photo 2    — affinity.serif.com — photo editor (cask deprecated)
-# Download: Aqua Voice          — withaqua.com — speech-to-text
-# Download: Steam Link          — apps.apple.com/app/id1246969117 — requires Rosetta 2 on Apple Silicon (softwareupdate --install-rosetta --agree-to-license)
+# Non-audio — manual install (direct license, not via Homebrew)
+# Download: Affinity Photo 2    — affinity.serif.com — photo editor (direct license; affinity-photo cask exists but installed manually)
 
 # ──────────────────────────────────────────────────────────────────
 # Quarantined — delete if still commented after 6 months
@@ -50,3 +50,5 @@ mas "Unread", id: 1363637349
 # cask "qflipper"          # Flipper Zero utility — 20260315
 # cask "signal"            # 20260315
 # cask "zen"               # 20260323
+# cask "aqua-voice"        # speech-to-text; dropped in rebuild — 20260619
+# mas  "Steam Link", id: 1246969117  # Intel-only (needs Rosetta); dropped in rebuild — 20260619

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -101,7 +101,7 @@ cask "ghostty"
 cask "google-chrome"
 cask "iina"                # video player
 cask "imageoptim"          # image optimizer
-cask "json-viewer"
+cask "karabiner-elements"  # keyboard remapper (system extension)
 cask "latest"              # app update checker
 cask "obsidian"
 cask "plexamp"
@@ -142,6 +142,7 @@ mas "Xcode", id: 497799835
 # brew "tree"                  # 20260313
 # brew "urlview"               # tmux-urlview plugin dep — 20260313
 # cask "jordanbaird-ice"       # menu bar manager — 20260315
+# cask "json-viewer"           # Intel-only; dropped in rebuild — 20260619
 # cask "keepingyouawake"       # 20260313
 # cask "pika"                  # color picker — 20260313
 # cask "shottr"                # screenshot tool — 20260313


### PR DESCRIPTION
Phase 3 of the Mac Studio "Delight" rebuild — codify high-value gaps into the repo before the wipe so the rebuild is automated and durable.

## Brewfiles
- Add `karabiner-elements` (universal — keyboard remap w/ system extension)
- Add `antinote` + `Marked 2` (id 890031187) to personal
- Quarantine `json-viewer` (Intel-only), `aqua-voice`, `Steam Link`
- Tailscale stays a manual standalone install (per RUNBOOK); Affinity Photo 2 stays a manual direct-license install

## macOS defaults (`config/macos/defaults.sh`)
22 new settings, all read from the live machine (audit found no drift):
- **Dock:** no-delay autohide, minimize-into-icon, magnification
- **Finder:** POSIX path in title, folders-first, ⌘Q to quit, 30-day trash, new windows → `~/Downloads`
- **Input:** key-repeat-on-hold (no accent menu), two-finger right-click, natural-scroll off
- **Text & Typing** (new section): disable autocorrect + all substitutions
- **System UI:** auto Light/Dark, force 24-hour time
- **Save & Files** (new section): expanded save panels, save-to-disk default, **no `.DS_Store` on network/USB shares**, no Time Machine new-disk prompt

## RUNBOOK
- New "audit `Brewfile.local` before a wipe" note (gitignored entries aren't codified → won't reinstall)
- Refreshed the macOS defaults description to match the script

Validated with `./install -n` (dotbot dry-run — clean; all link sources present) and `brew bundle` parse checks across all four Brewfiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
