### PR TITLE
🐛 Auto-trust Homebrew taps on install; RUNBOOK rebuild fixes

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -539,6 +539,7 @@ The installer is a thin wrapper around dotbot. Most failures are environmental.
 | `fatal: no submodule mapping found` | stale or uninitialized dotbot submodule | `git submodule update --init --recursive` |
 | `Error: <target> already exists and is not a link` | real file at symlink target (and `force` not set) | Back up the file, remove it, re-run `./install` |
 | Link succeeds but points to nothing | config file was moved or deleted in repo | Check `git status` for missing tracked files |
+| `brew bundle` errors on a `tap "..."` line (e.g. `cormacrelf/tap`) — *"tap … is not trusted"* | Homebrew 6+ ships `HOMEBREW_REQUIRE_TAP_TRUST` on by default and won't load non-official taps until trusted | `./install` auto-trusts every tap declared in the applicable Brewfiles before bundling. If it still trips (older checkout, or you ran `brew bundle` directly), run `brew trust --tap <tap>` once, then re-run |
 
 **Safe to re-run:** The installer is idempotent by design — re-running it won't duplicate symlinks, re-install already-installed Homebrew packages, or overwrite user-customizable configs (starship, ripgrep, bat, btop).
 
@@ -821,6 +822,12 @@ Add to the appropriate Brewfile and run `./install` (or `brew bundle` directly):
 - `packages/Brewfile.work` — work machines only
 - `packages/Brewfile.personal` — personal machines only
 - `packages/Brewfile.local` — this machine only (gitignored)
+
+**Adding a `tap`:** Homebrew 6+ requires non-official taps to be trusted before it
+will load them (`HOMEBREW_REQUIRE_TAP_TRUST`, default-on). `./install` pre-trusts
+every `tap "..."` line in the applicable Brewfiles automatically, so just add the
+`tap` and run `./install`. If you `brew bundle` directly instead, run
+`brew trust --tap <tap>` first. Commented-out tap lines are ignored.
 
 ### New zsh config
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -37,6 +37,16 @@ xcode-select --install
 
 Bootstrap will warn if missing. Required for git, compilers, and most dev tools.
 
+**If you installed the full Xcode app** (not just the Command Line Tools), accept
+its license before running `./install` — until you do, `xcodebuild` and any tool
+that shells out to it exit non-zero, which can break the installer mid-run:
+
+```sh
+sudo xcodebuild -license accept
+```
+
+CLT-only installs (`xcode-select --install`) don't need this step.
+
 ### 5. 1Password setup
 
 Bootstrap will install the app and CLI via Homebrew if you haven't already. Either way, you need to:
@@ -70,6 +80,26 @@ softwareupdate --install-rosetta --agree-to-license
 ```
 
 Steam Link specifically has been removed from `Brewfile.personal` for this reason — see the `# Download:` comment there for the manual install link.
+
+**Docker without Rosetta:** Docker Desktop does **not** require Rosetta. Rosetta
+only accelerates **x86_64/amd64** container images on Apple Silicon — arm64 images
+run natively. Most popular images are multi-arch (arm64), so a default workflow
+needs no Rosetta at all. To keep Docker Rosetta-free:
+
+- **Docker Desktop → Settings → General →** turn **off** *"Use Rosetta for
+  x86_64/amd64 emulation on Apple Silicon"*, then **Apply & restart**. (The toggle
+  is only active when *Virtual Machine Manager* is set to *Apple Virtualization
+  framework*, on the same tab; it defaults to off on a clean install.)
+- With it off, amd64 images fall back to **QEMU** — fully Rosetta-free but ~4–5×
+  slower. Prefer arm64 images; only reach for `--platform linux/amd64` when needed.
+- Switching runtimes does **not** avoid Rosetta: Apple's `container` framework and
+  Podman also use Rosetta for x86 emulation. The only Rosetta-free x86 path on any
+  runtime is QEMU.
+
+**Deprecation horizon:** Apple ships general-purpose Rosetta 2 through **macOS 27**
+(Golden Gate, fall 2026); **macOS 28** (fall 2027) removes it except for a narrow
+set of legacy game frameworks. If x86 containers ever become load-bearing, that
+2027 cutoff is the real deadline — install Rosetta on demand until then.
 
 ---
 
@@ -127,7 +157,13 @@ bash config/macos/defaults.sh
 
 Applies preferred system preferences: Dock (auto-hide with no delay, small icons, magnification, no recents, minimize-into-icon), Finder (list view, hidden files, extensions, POSIX path in title, folders-first, ⌘Q to quit, 30-day trash, new windows → `~/Downloads`), Input (fast key repeat, key-repeat-on-hold, tap-to-click, three-finger drag, two-finger right-click, natural-scroll off), Text & Typing (disable autocorrect + smart quotes/dashes/period/capitalization), screenshot location (`~/Pictures/Screenshots`), Mission Control (no hot corners, stable Spaces), System UI (auto Light/Dark, 24-hour clock, no date), and Save & Files (expanded save panels, save-to-disk default, **no `.DS_Store` on network/USB shares**, no Time Machine new-disk prompt).
 
-The script is idempotent and prompts before applying. It is **not** called by `./install` — run it manually on new machines. Most settings take effect immediately; input settings (key repeat, trackpad) may require logout or restart.
+The script is idempotent and prompts before applying. It is **not** called by `./install` — run it manually on new machines. Most settings take effect immediately (the script `killall`s Dock, Finder, etc.), but several — notably input settings (key repeat, trackpad) and some global UI prefs — aren't fully picked up until the next login.
+
+**Reboot after running the script** on a new machine to ensure everything applies cleanly:
+
+```sh
+sudo shutdown -r now
+```
 
 **After macOS upgrades:** Re-run the script after major upgrades (e.g. Sequoia). Major upgrades occasionally reset Dock, trackpad, and input settings. Minor updates almost never touch them. If a setting doesn't take effect after re-running, Apple likely changed or dropped the key — check `defaults read <domain>` to find the new key name.
 

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -128,6 +128,27 @@
     -
      command: 'command -v brew > /dev/null || { echo "⚠ Homebrew not found. Run ./bin/bootstrap.sh first or install manually."; }'
      description: Verify Homebrew is available
+    # Homebrew 6+ ships HOMEBREW_REQUIRE_TAP_TRUST on by default: it refuses to
+    # load non-official taps until they're trusted, so `brew bundle` errors on a
+    # fresh machine the first time it hits a `tap "..."` line. Pre-trust every
+    # tap declared in the applicable Brewfiles (the repo is the source of truth
+    # for what's intentionally installed). Idempotent; no-op on Homebrew < 6
+    # (no `trust` subcommand) and on non-brew hosts.
+    -
+     command: |
+       if command -v brew > /dev/null && brew trust --help > /dev/null 2>&1; then
+         for _bf in packages/Brewfile.universal \
+                    "$([[ -f ~/.work ]] && echo packages/Brewfile.work)" \
+                    "$([[ -f ~/.personal ]] && echo packages/Brewfile.personal)" \
+                    "$([[ -f packages/Brewfile.local ]] && echo packages/Brewfile.local)"; do
+           [[ -n "$_bf" && -f "$_bf" ]] || continue
+           grep -E '^[[:space:]]*tap ' "$_bf" | sed -E 's/.*tap "([^"]+)".*/\1/' | while read -r _tap; do
+             [[ -n "$_tap" ]] && brew trust --tap "$_tap" > /dev/null 2>&1 || true
+           done
+         done
+       fi
+     description: Trust non-official Homebrew taps declared in Brewfiles (Homebrew 6+)
+     stdout: true
     # --no-upgrade keeps ./install idempotent: missing packages install, but
     # already-installed casks/MAS apps that have self-updated past the cask
     # version stay put. Use `brew upgrade` for intentional upgrades.

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -102,7 +102,6 @@ cask "google-chrome"
 cask "iina"                # video player
 cask "imageoptim"          # image optimizer
 cask "karabiner-elements"  # keyboard remapper (system extension)
-cask "latest"              # app update checker
 cask "obsidian"
 cask "plexamp"
 cask "raycast"
@@ -156,3 +155,4 @@ mas "Xcode", id: 497799835
 # cask "itsycal"              # 20260322 - migrate to Dot
 # brew "zsh-history-substring-search" # 20260324 — replaced by built-in up-line-or-beginning-search
 # cask "zoom"                  # 20260406 — moved to Brewfile.personal; IT-managed on work machines
+# cask "latest"              # 20260620


### PR DESCRIPTION
Fixes surfaced while rebuilding the Mac Studio (Delight) from a clean wipe.

## Changes

### 🐛 Auto-trust non-official Homebrew taps (`install.config.yaml`)
Homebrew 6+ ships `HOMEBREW_REQUIRE_TAP_TRUST` on by default and refuses to load non-official taps until trusted, so `brew bundle` errored on the **first `./install` of every machine** when it hit `tap "cormacrelf/tap"` (dark-notify) in `Brewfile.universal`.

Added a pre-bundle step that trusts every `tap "..."` line declared in the applicable Brewfiles (universal + marker-selected + local). It is:
- **Idempotent** — `Already trusted` → exit 0
- **Safe** — no-op on Homebrew < 6 (no `trust` subcommand) and non-brew hosts
- **General** — also covers the work taps (`robscott`/`aws`/`hashicorp`) and any tap added later; skips commented-out tap lines

### 📝 RUNBOOK rebuild fixes (`docs/RUNBOOK.md`)
- **§4** — `sudo xcodebuild -license accept` before `./install` when the full Xcode app is installed (an unaccepted license breaks the installer mid-run)
- **§5** — explicit reboot after `macos/defaults.sh` (input/UI prefs don't apply until next login)
- **§6** — "Docker without Rosetta": the General-tab toggle, the QEMU fallback tradeoff, that Apple `container`/Podman don't escape Rosetta either, and the macOS 27→28 deprecation horizon

### 🧹 Quarantine `latest` cask (`packages/Brewfile.universal`)
Moved `cask "latest"` to the quarantine block (datestamped `20260620`); delete after 6 months if still unused, per the brew-audit framework.

## Testing
- YAML validated (ruby), trust command syntax-checked (`bash -n`), tap-extraction dry-run confirmed it picks only real taps and skips commented ones
- `brew trust --tap cormacrelf/tap` returns clean (idempotent)
- All commits SSH-signed; pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)