### PR TITLE
🔧 Track newest Claude Code release via claude-code@latest cask

### DIFF
--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -90,7 +90,7 @@ cask "1password"
 cask "1password-cli"
 cask "brave-browser"
 cask "claude"
-cask "claude-code"
+cask "claude-code@latest"  # tracks newest release
 cask "cleanshot"
 cask "desktoppr"           # set desktop wallpaper
 cask "docker-desktop"


### PR DESCRIPTION
## What

Switch the Brewfile entry from `cask "claude-code"` to `cask "claude-code@latest"`.

## Why

`claude-code@latest` is a separate cask in homebrew/cask (`Casks/c/claude-code@latest.rb`) that tracks the absolute newest release pulled directly from `downloads.claude.ai`, whereas the plain `claude-code` cask lags on a vetted/stable version (2.1.176 vs 2.1.185 at time of writing).

The `@latest` variant declares `conflicts_with "claude-code"` and is **already installed** on the Mac Studio at 2.1.185 — so this change simply brings the Brewfile in sync with what's actually on disk.

## Notes

- `@latest` is not generic Homebrew tag syntax; it's a real, separately-published cask name.
- Replacement, not addition — the two casks can't coexist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)