### PR TITLE
🔒 Prompt per tap before trusting instead of silent auto-trust

### DIFF
--- a/bin/brew-trust-taps
+++ b/bin/brew-trust-taps
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#
+# brew-trust-taps — interactively trust non-official Homebrew taps declared in
+# the applicable Brewfiles, one prompt per tap.
+#
+# Why prompt instead of auto-trust: Homebrew 6+ ships HOMEBREW_REQUIRE_TAP_TRUST
+# on by default and refuses to load non-official taps until they're trusted, so
+# `brew bundle` errors on a fresh machine the first time it hits a `tap "..."`
+# line. Auto-trusting every declared tap silently would defeat the point of that
+# safeguard — a poisoned or hijacked tap added to a Brewfile (by a bad merge, a
+# typo'd name resolving to a squatter, or an upstream compromise) would be
+# trusted without a human ever seeing it. Instead we surface each untrusted tap
+# with enough context (origin repo, declaring Brewfile, what it provides) to make
+# a deliberate trust decision, and trust only the ones you approve.
+#
+# Run automatically by ./install before `brew bundle`. Safe to run by hand too:
+#   brew-trust-taps
+#
+# Idempotent and self-guarding:
+#   - No-op where `brew` / `brew trust` is unavailable (Homebrew < 6, non-brew hosts).
+#   - Already-trusted taps are skipped silently.
+#   - Non-interactive (no TTY on stdin): trusts NOTHING, lists what needs trusting
+#     and the manual command, then exits 0 so ./install proceeds. `brew bundle`
+#     will surface the untrusted-tap error itself — the safe, visible default.
+
+# shellcheck disable=SC2088  # tilde in quoted output strings is intentional display text
+set -euo pipefail
+
+# Resolve this script's real location through any symlink (it is also linked into ~/bin).
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+  src_dir="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$src_dir/$SOURCE"
+done
+DOTFILES_DIR="$(cd -P "$(dirname "$SOURCE")/.." && pwd)"
+PACKAGES_DIR="$DOTFILES_DIR/packages"
+
+# --- Output helpers (match bin/bootstrap.sh style) ---
+
+if command -v tput >/dev/null 2>&1 && tput sgr0 >/dev/null 2>&1; then
+  BOLD=$(tput bold); GREEN=$(tput setaf 2); YELLOW=$(tput setaf 3); RED=$(tput setaf 1); RESET=$(tput sgr0)
+else
+  BOLD="" GREEN="" YELLOW="" RED="" RESET=""
+fi
+
+info()    { printf '%s[→]%s %s\n' "$BOLD"   "$RESET" "$1"; }
+success() { printf '%s[✓]%s %s\n' "$GREEN"  "$RESET" "$1"; }
+warn()    { printf '%s[!]%s %s\n' "$YELLOW" "$RESET" "$1"; }
+error()   { printf '%s[✗]%s %s\n' "$RED"    "$RESET" "$1"; }
+
+# --- Self-guard: need brew with the `trust` subcommand (Homebrew 6+) ---
+
+if ! command -v brew >/dev/null 2>&1 || ! brew trust --help >/dev/null 2>&1; then
+  exit 0
+fi
+
+# --- Collect taps declared in the applicable Brewfiles ---
+# Mirror install.config.yaml's selection: universal + marker-selected + local.
+
+brewfiles=("$PACKAGES_DIR/Brewfile.universal")
+[[ -f "$HOME/.work" ]]     && brewfiles+=("$PACKAGES_DIR/Brewfile.work")
+[[ -f "$HOME/.personal" ]] && brewfiles+=("$PACKAGES_DIR/Brewfile.personal")
+[[ -f "$PACKAGES_DIR/Brewfile.local" ]] && brewfiles+=("$PACKAGES_DIR/Brewfile.local")
+
+# Map of tap -> declaring Brewfile basename (first one wins). Track order separately
+# so output is deterministic.
+declare -a taps=()
+declare -A tap_source=()
+for bf in "${brewfiles[@]}"; do
+  [[ -f "$bf" ]] || continue
+  # `^[[:space:]]*tap "..."` only — commented-out tap lines are ignored.
+  while IFS= read -r tap; do
+    [[ -n "$tap" ]] || continue
+    if [[ -z "${tap_source[$tap]:-}" ]]; then
+      taps+=("$tap")
+      tap_source[$tap]="$(basename "$bf")"
+    fi
+  done < <(grep -E '^[[:space:]]*tap "' "$bf" | sed -E 's/.*tap "([^"]+)".*/\1/')
+done
+
+[[ ${#taps[@]} -eq 0 ]] && exit 0
+
+# --- Determine which taps are already trusted ---
+
+is_trusted() {
+  local tap="$1"
+  if command -v jq >/dev/null 2>&1; then
+    brew trust --json v1 2>/dev/null | jq -e --arg t "$tap" '.taps | index($t)' >/dev/null 2>&1
+  else
+    # Fallback: match the quoted tap name in the JSON array.
+    brew trust --json v1 2>/dev/null | grep -qF "\"$tap\""
+  fi
+}
+
+# Filter to untrusted taps.
+declare -a pending=()
+for tap in "${taps[@]}"; do
+  is_trusted "$tap" || pending+=("$tap")
+done
+
+[[ ${#pending[@]} -eq 0 ]] && exit 0
+
+# --- Context helpers ---
+
+# A tap "owner/repo" lives at github.com/owner/homebrew-repo.
+tap_url() {
+  local owner="${1%%/*}" repo="${1#*/}"
+  printf 'https://github.com/%s/homebrew-%s' "$owner" "$repo"
+}
+
+# List formulae/casks in the declaring Brewfile that reference this tap fully-
+# qualified ("owner/repo/name"), with any trailing comment, as decision context.
+tap_provides() {
+  local tap="$1" bf="$PACKAGES_DIR/${tap_source[$1]}"
+  [[ -f "$bf" ]] || return 0
+  # Match e.g.  brew "cormacrelf/tap/dark-notify"   # comment
+  grep -E "\"${tap}/[^\"]+\"" "$bf" | sed -E \
+    -e "s|.*\"${tap}/([^\"]+)\".*#[[:space:]]*(.*)|  · \1 — \2|" \
+    -e "s|.*\"${tap}/([^\"]+)\".*|  · \1|"
+}
+
+# --- Non-interactive: trust nothing, report, let brew bundle surface it ---
+
+if [[ ! -t 0 ]]; then
+  warn "Untrusted Homebrew tap(s) need a decision, but stdin is not a terminal."
+  for tap in "${pending[@]}"; do
+    printf '      %s (from %s)\n' "$tap" "${tap_source[$tap]}"
+  done
+  info "Re-run interactively:  brew-trust-taps"
+  info "Or trust one by hand:  brew trust --tap <owner/repo>"
+  exit 0
+fi
+
+# --- Interactive: one prompt per untrusted tap ---
+
+warn "${#pending[@]} non-official Homebrew tap(s) declared in your Brewfiles are not trusted."
+info "Homebrew won't load a non-official tap until you trust it. Review each below."
+printf '\n'
+
+trusted_count=0
+for tap in "${pending[@]}"; do
+  printf '%sTap:%s      %s\n' "$BOLD" "$RESET" "$tap"
+  printf '  Source:   %s\n' "${tap_source[$tap]}"
+  printf '  Origin:   %s\n' "$(tap_url "$tap")"
+  provides="$(tap_provides "$tap")"
+  if [[ -n "$provides" ]]; then
+    printf '  Provides:\n%s\n' "$provides"
+  fi
+  printf '%s[→]%s Trust %s? [y/N]: ' "$BOLD" "$RESET" "$tap"
+  read -r yn
+  case "$yn" in
+    [yY] | [yY][eE][sS])
+      if brew trust --tap "$tap" >/dev/null 2>&1; then
+        success "Trusted $tap"
+        trusted_count=$((trusted_count + 1))
+      else
+        error "Failed to trust $tap"
+      fi
+      ;;
+    *)
+      warn "Skipped $tap — packages from this tap will not install until trusted."
+      ;;
+  esac
+  printf '\n'
+done
+
+success "Done. Trusted $trusted_count of ${#pending[@]} tap(s) this run."

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -575,7 +575,7 @@ The installer is a thin wrapper around dotbot. Most failures are environmental.
 | `fatal: no submodule mapping found` | stale or uninitialized dotbot submodule | `git submodule update --init --recursive` |
 | `Error: <target> already exists and is not a link` | real file at symlink target (and `force` not set) | Back up the file, remove it, re-run `./install` |
 | Link succeeds but points to nothing | config file was moved or deleted in repo | Check `git status` for missing tracked files |
-| `brew bundle` errors on a `tap "..."` line (e.g. `cormacrelf/tap`) — *"tap … is not trusted"* | Homebrew 6+ ships `HOMEBREW_REQUIRE_TAP_TRUST` on by default and won't load non-official taps until trusted | `./install` auto-trusts every tap declared in the applicable Brewfiles before bundling. If it still trips (older checkout, or you ran `brew bundle` directly), run `brew trust --tap <tap>` once, then re-run |
+| `brew bundle` errors on a `tap "..."` line (e.g. `cormacrelf/tap`) — *"tap … is not trusted"* | Homebrew 6+ ships `HOMEBREW_REQUIRE_TAP_TRUST` on by default and won't load non-official taps until trusted | `./install` runs `brew-trust-taps`, which **prompts** for each untrusted tap (showing its origin repo and what it provides) before bundling — say yes to trust it. If a tap still trips (you declined it, ran `./install` non-interactively, ran `brew bundle` directly, or are on an older checkout), run `brew-trust-taps` interactively or `brew trust --tap <tap>` once, then re-run |
 
 **Safe to re-run:** The installer is idempotent by design — re-running it won't duplicate symlinks, re-install already-installed Homebrew packages, or overwrite user-customizable configs (starship, ripgrep, bat, btop).
 
@@ -860,10 +860,15 @@ Add to the appropriate Brewfile and run `./install` (or `brew bundle` directly):
 - `packages/Brewfile.local` — this machine only (gitignored)
 
 **Adding a `tap`:** Homebrew 6+ requires non-official taps to be trusted before it
-will load them (`HOMEBREW_REQUIRE_TAP_TRUST`, default-on). `./install` pre-trusts
-every `tap "..."` line in the applicable Brewfiles automatically, so just add the
-`tap` and run `./install`. If you `brew bundle` directly instead, run
-`brew trust --tap <tap>` first. Commented-out tap lines are ignored.
+will load them (`HOMEBREW_REQUIRE_TAP_TRUST`, default-on). `./install` runs
+`brew-trust-taps`, which **prompts you to approve each untrusted tap** declared in
+the applicable Brewfiles — it shows the tap's origin repo and what it provides so
+you can make a deliberate trust decision (auto-trusting silently would defeat the
+safeguard against a poisoned or typo-squatted tap). Add the `tap`, run `./install`,
+and answer `y` when prompted. Already-trusted taps are skipped; commented-out tap
+lines are ignored. If you `brew bundle` directly instead, run `brew-trust-taps` (or
+`brew trust --tap <tap>`) first. Non-interactive runs trust nothing and list what
+needs a decision.
 
 ### New zsh config
 

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -130,25 +130,15 @@
      description: Verify Homebrew is available
     # Homebrew 6+ ships HOMEBREW_REQUIRE_TAP_TRUST on by default: it refuses to
     # load non-official taps until they're trusted, so `brew bundle` errors on a
-    # fresh machine the first time it hits a `tap "..."` line. Pre-trust every
-    # tap declared in the applicable Brewfiles (the repo is the source of truth
-    # for what's intentionally installed). Idempotent; no-op on Homebrew < 6
-    # (no `trust` subcommand) and on non-brew hosts.
+    # fresh machine the first time it hits a `tap "..."` line. brew-trust-taps
+    # prompts for each untrusted tap (with origin + what it provides) rather than
+    # trusting them silently — auto-trusting would defeat the safeguard. Already-
+    # trusted taps are skipped; no-op on Homebrew < 6 and non-brew hosts.
     -
-     command: |
-       if command -v brew > /dev/null && brew trust --help > /dev/null 2>&1; then
-         for _bf in packages/Brewfile.universal \
-                    "$([[ -f ~/.work ]] && echo packages/Brewfile.work)" \
-                    "$([[ -f ~/.personal ]] && echo packages/Brewfile.personal)" \
-                    "$([[ -f packages/Brewfile.local ]] && echo packages/Brewfile.local)"; do
-           [[ -n "$_bf" && -f "$_bf" ]] || continue
-           grep -E '^[[:space:]]*tap ' "$_bf" | sed -E 's/.*tap "([^"]+)".*/\1/' | while read -r _tap; do
-             [[ -n "$_tap" ]] && brew trust --tap "$_tap" > /dev/null 2>&1 || true
-           done
-         done
-       fi
-     description: Trust non-official Homebrew taps declared in Brewfiles (Homebrew 6+)
+     command: 'bash bin/brew-trust-taps'
+     description: Review & trust non-official Homebrew taps declared in Brewfiles (Homebrew 6+)
      stdout: true
+     stdin: true
     # --no-upgrade keeps ./install idempotent: missing packages install, but
     # already-installed casks/MAS apps that have self-updated past the cask
     # version stay put. Use `brew upgrade` for intentional upgrades.


### PR DESCRIPTION
## Problem

PR #64 added an `./install` step that **silently** ran `brew trust --tap` on every tap declared in the applicable Brewfiles. That undercuts the very safeguard it works around — Homebrew 6+'s `HOMEBREW_REQUIRE_TAP_TRUST`. A poisoned, hijacked, or typo-squatted tap landing in a Brewfile (bad merge, upstream compromise, name resolving to a squatter) would be trusted with no human ever seeing it.

## Fix

Replace the inline auto-trust block in `install.config.yaml` with a new `bin/brew-trust-taps` script that asks for a deliberate, informed decision per tap:

- **Skips already-trusted taps** (reads `brew trust --json v1`) — idempotent, no nagging.
- **Prompts once per untrusted tap**, showing decision context (origin repo + what the tap provides), defaulting to **No**:
  ```
  Tap:      cormacrelf/tap
    Source:   Brewfile.universal
    Origin:   https://github.com/cormacrelf/homebrew-tap
    Provides:
    · dark-notify — macOS appearance change callback
  [→] Trust cormacrelf/tap? [y/N]:
  ```
- **Self-guards**: no-op on Homebrew < 6 / non-brew hosts.
- **Non-interactive runs** (no TTY) trust *nothing*, list what needs a decision plus the manual command, and exit 0 so `brew bundle` surfaces the untrusted-tap error itself — the safe, visible default.

`install.config.yaml` calls the script with `stdin: true` (dotbot's shell plugin supports it) so the prompt can read the terminal. `bin/*` is glob-symlinked to `~/bin`, so `brew-trust-taps` is also available as a standalone command.

`docs/RUNBOOK.md` updated in both spots (troubleshooting table + "Adding a `tap`" note).

## Verified

- Clean no-op on a machine where the tap is already trusted (exit 0).
- Non-interactive path trusts nothing and reports correctly (tested with an isolated `XDG_CONFIG_HOME` so the real trust store was untouched).
- `Provides`/`Origin` context extraction correct for universal and work taps.
- `shellcheck` clean; pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)