### PR TITLE
🔧 Make janitor skill squash-merge-aware when deleting local branch

### DIFF
--- a/config/claude/commands/janitor.md
+++ b/config/claude/commands/janitor.md
@@ -1,1 +1,12 @@
-Post-merge local repo cleanup. Capture the current branch name, switch to main, pull latest, and delete the old local branch. If already on main, just pull. Do not push or fetch --prune — just the three-step local cleanup. Do this without asking for confirmation.
+Post-merge local repo cleanup. Do this without asking for confirmation, and never push or `fetch --prune`.
+
+1. Capture the current branch name. If it is already `main`, just run `git pull` and stop.
+2. Switch to `main` and `git pull`.
+3. Delete the old local branch, squash-merge-aware:
+   - Try `git branch -d <branch>` first. If it succeeds, done.
+   - If it fails with "not fully merged", that's expected for squash/rebase merges (the merged commit has a new SHA, so the branch tip is never an ancestor of main). Before force-deleting, **confirm the branch was actually merged**:
+     - Authoritative check (preferred): `gh pr view <branch> --json state --jq .state` — if it returns `MERGED`, the branch is safe to delete with `git branch -D <branch>`.
+     - Fallback if `gh` is unavailable: squash-aware git check — `git cherry main $(git commit-tree "$(git rev-parse '<branch>^{tree}')" -p "$(git merge-base main <branch>)" -m _)`. Empty output means the branch's content is already in `main`; delete with `git branch -D <branch>`.
+   - If neither check confirms the branch is merged, do **not** delete it — warn that it may have unmerged work.
+
+Note: the repo has "automatically delete head branches" enabled on GitHub, so the remote branch is already gone after merge; this skill only cleans up the local branch.


### PR DESCRIPTION
## Problem

`/janitor` failed to delete the local branch on **every** run. `git branch -d` does a reachability check — it only deletes when the branch tip is an ancestor of `main`. Squash merges (and rebase merges) replay the work as a new commit with a new SHA, so the branch tip is *never* an ancestor of main. The delete refuses structurally, not occasionally.

## Fix

Two complementary changes:

1. **GitHub repo setting** — enabled `delete_branch_on_merge` ("automatically delete head branches"). Clears the *remote* branch on merge and gives a reliable merged-signal on the next fetch. (Applied via API; not part of this diff.)

2. **`config/claude/commands/janitor.md`** — make the local delete squash-merge-aware. Instead of relying on `-d`'s ancestry check, confirm the branch is genuinely merged before `git branch -D`:
   - Authoritative: `gh pr view <branch> --json state --jq .state` → `MERGED`.
   - Pure-git fallback (no `gh`): squash-aware `git cherry` against a synthetic commit of the branch tree.
   - If neither confirms merged, it does **not** delete and warns about possible unmerged work.

This preserves the safety `-d` gave (won't nuke unmerged work) while handling squash merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)