### PR TITLE
🐛 Fix tflint install (vendor tap) + surface failed brew bundles

### DIFF
--- a/install.config.yaml
+++ b/install.config.yaml
@@ -128,7 +128,9 @@
 
 - shell:
     -
-     command: 'command -v brew > /dev/null || { echo "⚠ Homebrew not found. Run ./bin/bootstrap.sh first or install manually."; }'
+     # Reset the failure log (consumed by the summary step at the end) before any
+     # bundle runs, so a clean install never reports stale failures.
+     command: 'rm -f "${TMPDIR:-/tmp}/dotfiles-brew-failures"; command -v brew > /dev/null || { echo "⚠ Homebrew not found. Run ./bin/bootstrap.sh first or install manually."; }'
      description: Verify Homebrew is available
     # Homebrew 6+ ships HOMEBREW_REQUIRE_TAP_TRUST on by default: it refuses to
     # load non-official taps until they're trusted, so `brew bundle` errors on a
@@ -144,20 +146,25 @@
     # --no-upgrade keeps ./install idempotent: missing packages install, but
     # already-installed casks/MAS apps that have self-updated past the cask
     # version stay put. Use `brew upgrade` for intentional upgrades.
+    # Each bundle step is non-blocking (install never aborts on a bad entry), but
+    # a failure is recorded to the log and surfaced by the summary step below —
+    # `brew bundle` aborts the *whole* file on one unresolved entry, so the rest
+    # of that Brewfile may be missing too. The `if`/`fi` guard means the warning
+    # fires only on a real bundle failure, never when the marker is just absent.
     -
-     command: '([[ "$(uname)" == "Darwin" ]] || [[ -f ~/.remote-full ]]) && brew bundle --no-upgrade --file=packages/Brewfile.universal || true'
+     command: 'if [[ "$(uname)" == "Darwin" ]] || [[ -f ~/.remote-full ]]; then brew bundle --no-upgrade --file=packages/Brewfile.universal || { echo "⚠ Brewfile.universal: some packages failed to install (see output above)"; echo "Brewfile.universal" >> "${TMPDIR:-/tmp}/dotfiles-brew-failures"; }; fi'
      description: Install universal Homebrew packages
      stdout: true
     -
-     command: '[[ -f ~/.work ]] && brew bundle --no-upgrade --file=packages/Brewfile.work || true'
+     command: 'if [[ -f ~/.work ]]; then brew bundle --no-upgrade --file=packages/Brewfile.work || { echo "⚠ Brewfile.work: some packages failed to install (see output above)"; echo "Brewfile.work" >> "${TMPDIR:-/tmp}/dotfiles-brew-failures"; }; fi'
      description: Install work Homebrew packages
      stdout: true
     -
-     command: '[[ -f ~/.personal ]] && brew bundle --no-upgrade --file=packages/Brewfile.personal || true'
+     command: 'if [[ -f ~/.personal ]]; then brew bundle --no-upgrade --file=packages/Brewfile.personal || { echo "⚠ Brewfile.personal: some packages failed to install (see output above)"; echo "Brewfile.personal" >> "${TMPDIR:-/tmp}/dotfiles-brew-failures"; }; fi'
      description: Install personal Homebrew packages
      stdout: true
     -
-     command: '[[ -f packages/Brewfile.local ]] && brew bundle --no-upgrade --file=packages/Brewfile.local || true'
+     command: 'if [[ -f packages/Brewfile.local ]]; then brew bundle --no-upgrade --file=packages/Brewfile.local || { echo "⚠ Brewfile.local: some packages failed to install (see output above)"; echo "Brewfile.local" >> "${TMPDIR:-/tmp}/dotfiles-brew-failures"; }; fi'
      description: Install local Homebrew packages
      stdout: true
     -
@@ -178,4 +185,24 @@
          launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.dnall.dark-notify.plist
        fi
      description: Load dark-notify LaunchAgent
+     stdout: true
+    -
+     command: |
+       fails="${TMPDIR:-/tmp}/dotfiles-brew-failures"
+       if [[ -s "$fails" ]]; then
+         echo ""
+         echo "═══════════════════════════════════════════════════════════════"
+         echo "⚠  Some Homebrew packages failed to install and need attention:"
+         while read -r bf; do
+           echo "     • $bf  →  recheck: brew bundle check --file=packages/$bf"
+         done < "$fails"
+         echo ""
+         echo "   One unresolved entry aborts the rest of that Brewfile, so other"
+         echo "   packages in it may be missing too. Fix or remove the entry, then"
+         echo "   re-run ./install."
+         echo "═══════════════════════════════════════════════════════════════"
+         rm -f "$fails"
+       fi
+       true
+     description: Report any Homebrew packages that failed to install
      stdout: true

--- a/packages/Brewfile.work
+++ b/packages/Brewfile.work
@@ -7,7 +7,6 @@ brew "aws-vault"
 brew "doitlive"
 brew "kubectx"        # switch k8s contexts
 brew "s3scanner"      # s3 bucket scanner
-brew "tflint"         # terraform linter
 # brew "terraform"    # quarantined 20260315 — migrating to mise
 # brew "tfenv"        # quarantined 20260315 — migrating to mise
 brew "yarn"
@@ -21,6 +20,10 @@ brew "aws/tap/eks-node-viewer"  # EKS node resource viewer
 
 tap "hashicorp/tap"
 brew "hashicorp/tap/packer"     # machine image building
+
+# tflint left homebrew-core; vendor ships it via their own tap
+tap "terraform-linters/tap"
+brew "terraform-linters/tap/tflint"  # terraform linter
 
 brew "eksctl"         # AWS EKS CLI
 brew "k9s"            # Kubernetes TUI


### PR DESCRIPTION
## Why

On a fresh work-machine `./install`, `kubectx` (and ansible, k9s, etc.) never installed. Root cause: **`tflint` was removed from `homebrew-core`**, so `brew bundle` couldn't resolve it. Because `brew bundle` resolves the entire file up front, one unresolvable entry **aborts the whole `Brewfile.work`** — every other formula in it silently failed too. The `|| true` in `install.config.yaml` then swallowed the error, so the failure was invisible.

## What

**`packages/Brewfile.work`**
- Install `tflint` from its official vendor tap `terraform-linters/tap` (it left homebrew-core). Matches the existing `robscott`/`aws`/`hashicorp` tap pattern. New machines will be prompted to trust the tap via `brew-trust-taps`, same as the others.

**`install.config.yaml`**
- Kept bundle steps **non-blocking** (a bad entry still aborts the rest of *its own* Brewfile — accepted limitation), but failures are no longer silent:
  - Each bundle step records a real failure to a temp log and prints an inline warning.
  - A final summary step prints a can't-miss boxed report listing which Brewfile(s) failed and the `brew bundle check` command to investigate.
  - The `if`/`fi` guard ensures the warning fires **only on an actual bundle failure**, never when a machine-type marker is simply absent. The log is reset at the start of every run, so clean installs never report stale failures.

## Verification

- `tflint` confirmed installed from the vendor tap on the work machine; full `Brewfile.work` now satisfies `brew bundle check`.
- All four bundle-step code paths verified to exit 0 (dotbot never aborts).
- YAML validated; pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)