### PR TITLE
🔧 Tune zsh-you-should-use to cut paste-noise

### DIFF
--- a/zsh/zshrc.zsh
+++ b/zsh/zshrc.zsh
@@ -50,6 +50,13 @@ setopt pushdtohome              # push to $HOME when no argument is given to `cd
 setopt pushdignoredups          # ignore duplicate entries in directory stack
 setopt autocd                   # if a command isn't valid, but is a directory, cd to that directory
 
+# zsh-you-should-use config (plugin loaded via sheldon, below). Tuned to keep the
+# learning benefit while cutting paste-noise: best-match only, reminder after the
+# command output, and an ignore list for aliases we routinely paste in full.
+export YSU_MODE="BESTMATCH"           # suggest only the single best alias, not every partial match
+export YSU_MESSAGE_POSITION="after"   # show reminder after the command runs, not before it
+export YSU_IGNORED_ALIASES=("g" "_" "vim" "e" "k8")  # git, sudo, editor, kubectl — fire on nearly every paste
+
 if command -v sheldon > /dev/null && [[ -t 1 ]]; then
   export SHELDON_CONFIG_DIR="$XDG_CONFIG_HOME/sheldon"
   export SHELDON_DATA_DIR="$XDG_DATA_HOME/sheldon"


### PR DESCRIPTION
## What

Tunes the [`zsh-you-should-use`](https://github.com/MichaelAquilina/zsh-you-should-use) plugin (loaded via sheldon) to keep its alias-learning benefit while reducing nags on copy/pasted commands.

Adds three `YSU_*` settings in `zsh/zshrc.zsh`, just before the sheldon source so they're set when the plugin's `preexec` hook reads them:

- `YSU_MODE="BESTMATCH"` — suggest only the single best alias, not every partial match
- `YSU_MESSAGE_POSITION="after"` — show the reminder after command output instead of before (no longer shoves the prompt down)
- `YSU_IGNORED_ALIASES=("g" "_" "vim" "e" "k8")` — silence the short aliases that fire on nearly every pasted `git` / `sudo` / editor / `kubectl` command

## Why

The reminders are great for learning the longer, less-obvious aliases (`gfa`, `glgga`, `gstp`, …), but were noisy when pasting commands not written with the aliases — especially `g='git'` and `_='sudo'`, which match almost everything.

## Testing

Reloaded the shell and confirmed: pasted `git`/`kubectl` commands are now silent, while non-ignored aliases still get a single best-match reminder shown after output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)