### PR TITLE
♻️ Extract brew + dark-notify install steps into bin/ scripts

### DIFF
--- a/bin/brew-bundle-install
+++ b/bin/brew-bundle-install
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# brew-bundle-install — install one Brewfile's packages, recording any failure
+# for the end-of-install summary (see brew-report-failures).
+#
+# Usage: brew-bundle-install <universal|work|personal|local>
+#
+# Given a Brewfile key, this applies the same marker-based selection ./install
+# uses (so a hand-run behaves identically) and installs packages/Brewfile.<key>:
+#   universal — macOS, or a ~/.remote-full Linux box
+#   work      — ~/.work marker present
+#   personal  — ~/.personal marker present
+#   local     — packages/Brewfile.local exists (machine-specific, gitignored)
+# When the selection doesn't apply, it's a silent no-op (exit 0).
+#
+# `brew bundle` resolves the whole file up front, so a single unresolvable entry
+# (e.g. a formula removed from homebrew-core) aborts the rest of THAT Brewfile,
+# leaving its other packages uninstalled. We don't want that to abort ./install,
+# so this ALWAYS exits 0; on failure it appends the Brewfile's name to a shared
+# failure log that brew-report-failures reads at the very end and turns into an
+# actionable summary. --no-upgrade keeps ./install install-only (missing packages
+# install; self-updating casks aren't downgraded to the pinned version).
+#
+# Keeping selection here (not inline in install.config.yaml) keeps the installer
+# output tidy: dotbot echoes the short command, not a wall of shell.
+
+set -uo pipefail
+
+key="${1:?usage: brew-bundle-install <universal|work|personal|local>}"
+
+# Apply the same selection install.config.yaml / brew-trust-taps use.
+case "$key" in
+  universal) [[ "$(uname)" == "Darwin" || -f "$HOME/.remote-full" ]] || exit 0 ;;
+  work)      [[ -f "$HOME/.work" ]]     || exit 0 ;;
+  personal)  [[ -f "$HOME/.personal" ]] || exit 0 ;;
+  local)     : ;;  # gated only by the Brewfile's existence, checked below
+  *) echo "brew-bundle-install: unknown Brewfile key '$key'" >&2; exit 2 ;;
+esac
+
+# Resolve this script's real location through any symlink (it is also linked into
+# ~/bin), so the packages/ path resolves regardless of the caller's cwd.
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+  src_dir="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ "$SOURCE" != /* ]] && SOURCE="$src_dir/$SOURCE"
+done
+DOTFILES_DIR="$(cd -P "$(dirname "$SOURCE")/.." && pwd)"
+
+brewfile="Brewfile.$key"
+path="$DOTFILES_DIR/packages/$brewfile"
+fails="${TMPDIR:-/tmp}/dotfiles-brew-failures"
+
+command -v brew >/dev/null 2>&1 || exit 0
+[[ -f "$path" ]] || exit 0
+
+if ! brew bundle --no-upgrade --file="$path"; then
+  printf '⚠ %s: some packages failed to install (see output above)\n' "$brewfile"
+  printf '%s\n' "$brewfile" >> "$fails"
+fi
+
+exit 0

--- a/bin/brew-report-failures
+++ b/bin/brew-report-failures
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# brew-report-failures — print an end-of-install summary of any Brewfiles whose
+# `brew bundle` step failed during ./install, then clear the failure log.
+#
+# The log is reset before bundling begins (in install.config.yaml) and appended
+# to by brew-bundle-install on each failure. Because `brew bundle` aborts the
+# whole file on one unresolved entry, a failure here means other packages in that
+# Brewfile may be missing too — hence the pointer to `brew bundle check`.
+#
+# No-op (exit 0) when nothing failed.
+
+set -uo pipefail
+
+fails="${TMPDIR:-/tmp}/dotfiles-brew-failures"
+[[ -s "$fails" ]] || exit 0
+
+bar="═══════════════════════════════════════════════════════════════"
+printf '\n%s\n' "$bar"
+printf '⚠  Some Homebrew packages failed to install and need attention:\n'
+while IFS= read -r bf; do
+  [[ -n "$bf" ]] || continue
+  printf '     • %s  →  recheck: brew bundle check --file=packages/%s\n' "$bf" "$bf"
+done < "$fails"
+printf '\n'
+printf '   One unresolved entry aborts the rest of that Brewfile, so other\n'
+printf '   packages in it may be missing too. Fix or remove the entry, then\n'
+printf '   re-run ./install.\n'
+printf '%s\n' "$bar"
+
+rm -f "$fails"

--- a/bin/dark-notify-load
+++ b/bin/dark-notify-load
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# dark-notify-load — (re)load the dark-notify LaunchAgent that drives automatic
+# dark/light theme switching (see docs/RUNBOOK.md § Theme Switching).
+#
+# bootout first (ignoring "not loaded" errors), then bootstrap, so re-running
+# ./install picks up a changed plist instead of erroring on an already-loaded
+# agent. No-op (exit 0) on non-macOS or where dark-notify isn't installed
+# (e.g. remote/minimal machines).
+#
+# Run by ./install. Safe to run by hand:
+#   dark-notify-load
+
+set -uo pipefail
+
+[[ "$(uname)" == "Darwin" ]] || exit 0
+command -v dark-notify >/dev/null 2>&1 || exit 0
+
+plist="$HOME/Library/LaunchAgents/com.dnall.dark-notify.plist"
+domain="gui/$(id -u)"
+
+launchctl bootout "$domain" "$plist" 2>/dev/null || true
+launchctl bootstrap "$domain" "$plist"

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -439,7 +439,9 @@ Desktop wallpaper (macOS):
 **LaunchAgent not running:**
 ```sh
 launchctl list | grep dark-notify
-# If missing:
+# If missing, reload it (bootout + bootstrap; no-op off macOS / without dark-notify):
+dark-notify-load
+# Or the raw command it wraps:
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.dnall.dark-notify.plist
 ```
 

--- a/install.config.yaml
+++ b/install.config.yaml
@@ -132,6 +132,7 @@
      # bundle runs, so a clean install never reports stale failures.
      command: 'rm -f "${TMPDIR:-/tmp}/dotfiles-brew-failures"; command -v brew > /dev/null || { echo "⚠ Homebrew not found. Run ./bin/bootstrap.sh first or install manually."; }'
      description: Verify Homebrew is available
+     stdout: true
     # Homebrew 6+ ships HOMEBREW_REQUIRE_TAP_TRUST on by default: it refuses to
     # load non-official taps until they're trusted, so `brew bundle` errors on a
     # fresh machine the first time it hits a `tap "..."` line. brew-trust-taps
@@ -143,28 +144,25 @@
      description: Review & trust non-official Homebrew taps declared in Brewfiles (Homebrew 6+)
      stdout: true
      stdin: true
-    # --no-upgrade keeps ./install idempotent: missing packages install, but
-    # already-installed casks/MAS apps that have self-updated past the cask
-    # version stay put. Use `brew upgrade` for intentional upgrades.
-    # Each bundle step is non-blocking (install never aborts on a bad entry), but
-    # a failure is recorded to the log and surfaced by the summary step below —
-    # `brew bundle` aborts the *whole* file on one unresolved entry, so the rest
-    # of that Brewfile may be missing too. The `if`/`fi` guard means the warning
-    # fires only on a real bundle failure, never when the marker is just absent.
+    # Each bundle step is non-blocking: brew-bundle-install applies the marker-
+    # based selection, always exits 0, and on failure records the Brewfile name to
+    # a log that the summary step at the end of this block turns into an actionable
+    # report. (`brew bundle` aborts the *whole* file on one unresolved entry, so
+    # the rest of that Brewfile may be missing too.)
     -
-     command: 'if [[ "$(uname)" == "Darwin" ]] || [[ -f ~/.remote-full ]]; then brew bundle --no-upgrade --file=packages/Brewfile.universal || { echo "⚠ Brewfile.universal: some packages failed to install (see output above)"; echo "Brewfile.universal" >> "${TMPDIR:-/tmp}/dotfiles-brew-failures"; }; fi'
+     command: 'bash bin/brew-bundle-install universal'
      description: Install universal Homebrew packages
      stdout: true
     -
-     command: 'if [[ -f ~/.work ]]; then brew bundle --no-upgrade --file=packages/Brewfile.work || { echo "⚠ Brewfile.work: some packages failed to install (see output above)"; echo "Brewfile.work" >> "${TMPDIR:-/tmp}/dotfiles-brew-failures"; }; fi'
+     command: 'bash bin/brew-bundle-install work'
      description: Install work Homebrew packages
      stdout: true
     -
-     command: 'if [[ -f ~/.personal ]]; then brew bundle --no-upgrade --file=packages/Brewfile.personal || { echo "⚠ Brewfile.personal: some packages failed to install (see output above)"; echo "Brewfile.personal" >> "${TMPDIR:-/tmp}/dotfiles-brew-failures"; }; fi'
+     command: 'bash bin/brew-bundle-install personal'
      description: Install personal Homebrew packages
      stdout: true
     -
-     command: 'if [[ -f packages/Brewfile.local ]]; then brew bundle --no-upgrade --file=packages/Brewfile.local || { echo "⚠ Brewfile.local: some packages failed to install (see output above)"; echo "Brewfile.local" >> "${TMPDIR:-/tmp}/dotfiles-brew-failures"; }; fi'
+     command: 'bash bin/brew-bundle-install local'
      description: Install local Homebrew packages
      stdout: true
     -
@@ -179,30 +177,12 @@
      command: 'command -v pre-commit > /dev/null && [ -d .git ] && pre-commit install || true'
      description: Install pre-commit git hooks
     -
-     command: |
-       if [[ "$(uname)" == "Darwin" ]] && command -v dark-notify > /dev/null; then
-         launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.dnall.dark-notify.plist 2>/dev/null || true
-         launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.dnall.dark-notify.plist
-       fi
+     command: 'bash bin/dark-notify-load'
      description: Load dark-notify LaunchAgent
      stdout: true
+    # Prints a summary of any Brewfiles whose bundle step failed (see
+    # brew-bundle-install), then clears the log. Silent when nothing failed.
     -
-     command: |
-       fails="${TMPDIR:-/tmp}/dotfiles-brew-failures"
-       if [[ -s "$fails" ]]; then
-         echo ""
-         echo "═══════════════════════════════════════════════════════════════"
-         echo "⚠  Some Homebrew packages failed to install and need attention:"
-         while read -r bf; do
-           echo "     • $bf  →  recheck: brew bundle check --file=packages/$bf"
-         done < "$fails"
-         echo ""
-         echo "   One unresolved entry aborts the rest of that Brewfile, so other"
-         echo "   packages in it may be missing too. Fix or remove the entry, then"
-         echo "   re-run ./install."
-         echo "═══════════════════════════════════════════════════════════════"
-         rm -f "$fails"
-       fi
-       true
+     command: 'bash bin/brew-report-failures'
      description: Report any Homebrew packages that failed to install
      stdout: true


### PR DESCRIPTION
## Why

The recently-added brew failure-surfacing logic and the dark-notify LaunchAgent loader lived as fat inline shell in `install.config.yaml`. dotbot echoes every shell step as `description [command]`, so these dumped 270-char one-liners and multi-line blocks on every `./install` — noisy on clean runs, unhelpful on failures.

`quiet: true` isn't the fix: in this repo's vendored dotbot, it drops the whole step line to `INFO` level (below the default `ACTION`), hiding the helpful description too. So instead this shrinks the *command* by extracting the logic into scripts.

## What

Three self-guarding `bin/` scripts so dotbot echoes a tidy `description [bash bin/foo]`:

- **`brew-bundle-install <universal|work|personal|local>`** — applies the marker-based selection, runs `brew bundle --no-upgrade`, records failures to a log, always exits 0 (non-blocking, as before).
- **`brew-report-failures`** — prints the end-of-install summary box if any Brewfile failed, then clears the log. Silent otherwise.
- **`dark-notify-load`** — bootout + bootstrap the theme-switch LaunchAgent; no-op off macOS or without `dark-notify`.

Also:
- Added `stdout: true` to the "Verify Homebrew" step so its not-found warning is actually visible (was suppressed).
- Pointed the RUNBOOK dark-notify troubleshooting at `dark-notify-load`.

Behavior is unchanged; the scripts auto-symlink into `~/bin` via the existing `bin/*` glob.

## Before → after (echoed step)

```
Install local Homebrew packages [if [[ -f packages/Brewfile.local ]]; then brew bundle --no-upgrade --file=packages/Brewfile.local || { echo "⚠ …"; echo "Brewfile.local" >> "${TMPDIR:-/tmp}/…"; }; fi]
```
→
```
Install local Homebrew packages [bash bin/brew-bundle-install local]
```

## Verification

- Failure path with a stubbed failing `brew`: records → summary box → log cleared ✓
- Marker guards (`work` no-ops without `~/.work`), unknown key → exit 2, missing Brewfile → no-op ✓
- `dark-notify-load` ran live: reloaded the agent, confirmed running in `launchctl list` ✓
- `./install --dry-run` shows the tidy echoes; YAML valid; shellcheck clean; pre-commit hooks pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)