### PR TITLE
✨ Add raycast-doctor + document Raycast v1/v2 beta coexistence

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -5,7 +5,7 @@
 >
 > **Repo:** `~/.dotfiles` (Dotbot-managed, macOS/zsh-centric, with Linux remote support)
 >
-> **Previous:** v6.0 Claude Code settings — install-time layered merge — completed. `bin/claude-settings-build` deep-merges layered source files (`config/claude/settings.{shared,<marker>,local}.json`) into the untracked, real `~/.claude/settings.json`, ending runtime churn and keeping secrets out of the public repo.
+> **Previous:** v7.0 NordicPine dark-mode readability — completed. Fixed unreadable `bat` comments (Brewfile.* syntax mapping + custom `nordicpine.tmTheme`), split the near-duplicate blue/cyan palette slots (ΔE 5 → 23), and aligned Neovim treesitter groups onto the NordicPine palette with a lossless dark↔light toggle.
 
 ---
 
@@ -33,72 +33,67 @@ After all cleanup work is complete, these must all be true:
 
 ## Part B: Task Plan
 
-### Project: NordicPine dark-mode readability + full-stack palette coherence
+### Project: Raycast v2 beta coexistence — protect scripts + Brewfile
 
 **Problem**
 
-Dark-mode `bat` rendered comments as near-invisible dim slate, and `Brewfile.*` files
-showed no syntax highlighting at all. Root causes, in the order they surfaced:
+Migrating to the [Raycast v2 beta](https://www.raycast.com/new) raised two fears: (1) that
+`brew bundle` would clobber the beta and reinstall v1, and (2) that the dotfiles-managed
+`config/raycast/scripts/*` script commands would break. Investigation showed both fears are
+largely unfounded given how Raycast actually ships v2 — the work is to document that and add
+a guardrail so a future cleanup doesn't reintroduce the risk.
 
-1. **No syntax highlighting on `Brewfile.universal/.work/.personal/.local`** — bat maps
-   only the exact name `Brewfile` → Ruby; the suffixed variants fell back to plain text,
-   so every token (comments included) rendered as the bare foreground. This was the
-   actual "comments unreadable" cause — masked because the first screenshot was Neovim,
-   not bat.
-2. **`bat` dark theme was `base16`**, which borrows the terminal's 16 ANSI colors;
-   comments mapped to ANSI bright-black `#343b51`, ~1.7:1 contrast on the `#0f111a` bg.
-   `#343b51` does double duty as a structural color (borders, tmux bg), so it could not
-   simply be lightened globally.
-3. **NordicPine palette had low hue diversity** — palette-4 (blue `#257994`) and
-   palette-6 (cyan `#33859d`) were ΔE≈5 apart, collapsing distinct syntax scopes; and the
-   bat tmTheme reused one teal across `support.function` / `entity.name.function`.
-4. **Neovim treesitter bleed** — rose-pine themes the `@`-capture groups explicitly, so
-   the legacy `Function`/`Type`/`Constant` overrides never reached treesitter-highlighted
-   code: ~20 semantic groups were rendering rose-pine defaults, not NordicPine.
+Findings (verified on a live machine):
+
+1. **v1 and v2 are separate apps.** v1 = `/Applications/Raycast.app` (`com.raycast.macos`);
+   v2 beta = `/Applications/Raycast Beta.app` (`com.raycast-x.macos`), separate settings
+   stores. They coexist by design; neither bundle can clobber the other.
+2. **The Brewfile can't clobber the beta.** No `raycast@beta` cask exists (checked the
+   Homebrew API — `raycast@beta`/`raycast-beta`/`raycast-x` all 404), so the beta is a manual
+   install. `bin/brew-bundle-install` runs `brew bundle --no-upgrade` (a no-op for the
+   already-installed v1), and nothing in the install path runs `brew bundle cleanup`/`zap`.
+3. **Script commands are compatible.** Plain shell + `@raycast.*` metadata; v2 supports the
+   same format. `~/.config/raycast/scripts` is app-agnostic.
+4. **Registration carries over on migration.** v2's separate settings store would in
+   principle need the script directory re-registered — but its "Migrate from Raycast v1"
+   onboarding does this automatically (verified: no manual action needed). Only relevant if
+   migration is skipped. The registration is NOT in NSUserDefaults, so it can be reminded
+   about but not verified programmatically.
 
 **Decisions**
 
-- **Keep NordicPine** (test-drove Gotham / Iceberg / Moonfly / Kanagawa Wave; NordicPine
-  won the "dark + high text-to-bg contrast + dusty/muted, no purple" brief — Gotham failed
-  on contrast not darkness, Moonfly was too vivid). User taste captured in auto-memory
-  `theme-color-preferences`.
-- bat dark theme = custom `config/bat/themes/nordicpine.tmTheme` (mirrors light-mode
-  `rose-pine-dawn.tmTheme`); every color traces to `docs/color-palettes.md`.
-- Comments = Autosuggest `#555e7a` everywhere (readable, palette-faithful); `#343b51`
-  retired to structural-only (borders / invisibles).
-- palette-4 `#257994 → #2a5f8f` (blue ≠ cyan, ΔE 5 → 23) across all role usages.
-- Light mode stays clean Rosé Pine Dawn / AlpineDawn — dark overrides must fully toggle off.
+- **Keep `cask "raycast"` (v1)** during the beta (Raycast recommends coexistence; the beta
+  still lacks some features). Add a comment so it isn't "cleaned up."
+- **Beta stays a manual install** — no cask to add yet. Revisit if/when `raycast@beta` lands.
+- **Guardrail = a read-only doctor**, not an install-time gate, since the one unverifiable
+  step (script-dir registration) can only be reminded, not enforced. Model it on
+  `bin/brew-audit.sh` (colored, read-only, exit 0).
 
 **Tasks**
 
-- [x] **bat syntax mapping** — `--map-syntax "Brewfile.*:Ruby"` in `config/bat/config`.
-- [x] **bat dark theme** — new `nordicpine.tmTheme`; `--theme-dark="nordicpine"`; symlink
-      entry in `install.config.yaml`; `bat cache --build`. Builtins (`support.function`)
-      → blue, user functions teal; readable `gutterForeground` + pink grid.
-- [x] **Palette blue/cyan split** — palette-4 → `#2a5f8f` in `ghostty/themes/NordicPine`,
-      `color-palettes.md`, `starship.toml` ×2, `tmux-nordic.conf`. palette-8
-      `#343b51 → #555e7a` (Ghostty + doc ANSI table).
-- [x] **Readable comments across the stack** — `#343b51 → #555e7a` in nvim
-      `appearance.lua`, `vim/colors/nordicpine.vim`, `zsh/lib/theme.zsh`.
-- [x] **nvim treesitter alignment** — ~20 `@`-groups mapped onto the NordicPine palette in
-      `appearance.lua` (functions teal + builtins blue, types cyan, constants gold,
-      variables fg, `self`/labels pink, tags blue, punctuation slate).
-- [x] **Doc sync** — `color-palettes.md`: ANSI-8 → `#555e7a`; relabel `#343b51`
-      (borders/invisibles) and `#555e7a` (autosuggest/comments).
+- [x] **`bin/raycast-doctor`** — detects installed v1/v2 apps, checks the
+      `~/.config/raycast/scripts` symlink, lists tracked script commands, prints the
+      per-app manual-registration reminder. Read-only, exit 0, macOS-guarded. Auto-symlinked
+      into `~/bin` via the existing `bin/*` glob (no `install.config.yaml` change).
+- [x] **`packages/Brewfile.universal`** — comment on `cask "raycast"` explaining v1 is kept
+      intentionally, no beta cask exists, and brew won't clobber the beta.
+- [x] **`docs/RUNBOOK.md`** — new "Raycast v1 vs v2 beta" subsection (comparison table +
+      key points) and a v2 note on the one-time setup step; reference `raycast-doctor`.
+- [x] **`docs/ARCHITECTURE.md`** — note the scripts dir is shared by v1 and the separate v2
+      app.
+- [x] **`SPEC.md`** — rotate Part B to this project.
 
-**Status:** Implemented on branch `feat/nordicpine-dark-readability`. Verified live: bat
-renders Brewfiles with readable comments and builtin ≠ user-function colors; nvim dark
-mode is full NordicPine across legacy + treesitter groups. A headless `dark → light →
-dark` toggle confirms every override clears to clean Rosé Pine Dawn and restores with no
-leakage in either direction; ΔE math confirms the blue/cyan separation (5 → 23). Shipped
-as a 3-commit split: `🔧` drop deprecated `docker-completion` (pre-existing working-tree
-change) + `🐛` Brewfile.* map-syntax + `🎨` NordicPine dark-mode overhaul.
+**Status:** Implemented on branch `feat/raycast-v2-beta-coexistence`. `raycast-doctor` runs
+clean on a live machine with both apps installed (v1 + v2 beta detected, symlink healthy,
+`quick-capture-obsidian.sh` listed). Applies across work and personal machines via the
+universal Brewfile + `bin/*` glob symlink.
 
 **Acceptance**
 
-- bat dark mode: `Brewfile.*` highlight; comments legible (`#555e7a`, ~2.9:1);
-  builtins ≠ user functions.
-- nvim: dark = NordicPine across legacy + treesitter; light = clean Rosé Pine Dawn; the
-  dark↔light toggle is lossless in both directions.
-- NordicPine 16-color palette has no near-duplicate slots (blue ≠ cyan, ΔE ≥ ~20).
-- All theme colors trace to `docs/color-palettes.md`.
+- `raycast-doctor` reports installed apps, symlink health, and tracked scripts; exits 0; is
+  a no-op on non-macOS.
+- `cask "raycast"` carries a comment documenting the intentional v1/v2 coexistence.
+- RUNBOOK + ARCHITECTURE accurately describe the separate-app model and the per-app
+  script-directory registration.
+- No install-path change auto-removes or downgrades the beta (no `cleanup`/`zap`;
+  `--no-upgrade` retained).

--- a/bin/raycast-doctor
+++ b/bin/raycast-doctor
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# raycast-doctor — Raycast script-command health check (v1 + v2 beta coexistence)
+#
+# Read-only diagnostic. Reports which Raycast apps are installed, whether the
+# dotfiles-managed script directory is symlinked correctly, and which script
+# commands it contains. Because Raycast v1 (com.raycast.macos) and v2 beta
+# (com.raycast-x.macos) are SEPARATE apps with SEPARATE settings stores, the
+# "Add Script Directory" registration is per-app — but v2's "Migrate from Raycast
+# v1" onboarding carries it over automatically. It is NOT stored in NSUserDefaults,
+# so this script can only remind you, not verify it. Makes no changes; exits 0.
+#
+# Usage:
+#   raycast-doctor        # run via ~/bin symlink
+#   bin/raycast-doctor    # run directly
+
+set -uo pipefail
+
+# --- Resolve dotfiles directory ---
+
+if [[ -n "${DOTFILES:-}" ]]; then
+  DOTFILES_DIR="$DOTFILES"
+else
+  SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")")" && pwd)"
+  DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+
+SCRIPTS_SRC="$DOTFILES_DIR/config/raycast/scripts"
+SCRIPTS_LINK="$HOME/.config/raycast/scripts"
+
+# --- Output helpers (mirror bin/brew-audit.sh) ---
+
+tput_available() { command -v tput >/dev/null 2>&1; }
+
+if tput_available; then
+  BOLD=$(tput bold)
+  GREEN=$(tput setaf 2)
+  YELLOW=$(tput setaf 3)
+  RED=$(tput setaf 1)
+  DIM=$(tput dim)
+  RESET=$(tput sgr0)
+else
+  BOLD="" GREEN="" YELLOW="" RED="" DIM="" RESET=""
+fi
+
+header()  { printf '\n%s=== %s ===%s\n' "$BOLD" "$1" "$RESET"; }
+ok()      { printf '  %s✓%s %s\n' "$GREEN" "$RESET" "$1"; }
+finding() { printf '  %s•%s %s\n' "$YELLOW" "$RESET" "$1"; }
+bad()     { printf '  %s✗%s %s\n' "$RED" "$RESET" "$1"; }
+info()    { printf '  %s%s%s\n' "$DIM" "$1" "$RESET"; }
+
+printf '%sRaycast Doctor%s — %s\n' "$BOLD" "$RESET" "$(hostname -s)"
+printf '%s\n' "$(date '+%Y-%m-%d %H:%M')"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  info "Not macOS — Raycast is macOS-only. Nothing to check."
+  exit 0
+fi
+
+# --- Installed Raycast apps ---
+# v1 and v2 beta are distinct app bundles / bundle IDs and coexist by design.
+
+header "Installed Raycast apps"
+
+v1_app="/Applications/Raycast.app"
+v2_app="/Applications/Raycast Beta.app"
+
+if [[ -d "$v1_app" ]]; then
+  ok "Raycast v1 (com.raycast.macos) — $v1_app"
+else
+  finding "Raycast v1 not found at $v1_app (managed by 'cask \"raycast\"')"
+fi
+
+if [[ -d "$v2_app" ]]; then
+  ok "Raycast v2 beta (com.raycast-x.macos) — $v2_app"
+else
+  finding "Raycast v2 beta not installed."
+  info "No Homebrew cask exists yet — install manually from https://www.raycast.com/new"
+  info "(v2 beta requires macOS Tahoe; it installs alongside v1, not over it.)"
+fi
+
+# --- Script directory symlink (dotbot-managed) ---
+
+header "Script directory symlink"
+
+if [[ -L "$SCRIPTS_LINK" ]]; then
+  target="$(readlink "$SCRIPTS_LINK")"
+  if [[ "$target" == "$SCRIPTS_SRC" ]]; then
+    ok "$SCRIPTS_LINK → $target"
+  else
+    bad "$SCRIPTS_LINK → $target"
+    info "Expected → $SCRIPTS_SRC. Re-run ./install to fix the dotbot symlink."
+  fi
+elif [[ -e "$SCRIPTS_LINK" ]]; then
+  bad "$SCRIPTS_LINK exists but is NOT a symlink."
+  info "Expected a dotbot symlink → $SCRIPTS_SRC. Re-run ./install."
+else
+  bad "$SCRIPTS_LINK does not exist."
+  info "Run ./install to create the dotbot symlink → $SCRIPTS_SRC."
+fi
+
+# --- Tracked script commands ---
+
+header "Tracked script commands"
+
+shopt -s nullglob
+found=0
+for f in "$SCRIPTS_SRC"/*.sh; do
+  base="$(basename "$f")"
+  [[ "$base" == *.template.sh ]] && continue
+  title="$(sed -n 's/^# @raycast\.title[[:space:]]*//p' "$f" | head -1)"
+  exec_flag=""; [[ -x "$f" ]] || exec_flag=" ${YELLOW}(not executable — chmod +x)${RESET}"
+  printf '  %s•%s %s%s%s%s\n' "$GREEN" "$RESET" "$base" \
+    "${title:+  — }" "${title:-}" "$exec_flag"
+  found=$((found + 1))
+done
+shopt -u nullglob
+[[ $found -eq 0 ]] && info "No script commands found in $SCRIPTS_SRC"
+
+# --- Manual registration reminder (not machine-verifiable) ---
+
+header "Registering the directory (per app)"
+
+info "The script-directory registration lives in Raycast's internal store, not in"
+info "NSUserDefaults, so it can't be verified here. v2 beta's 'Migrate from Raycast"
+info "v1' onboarding carries it over automatically — only do this by hand if you"
+info "skipped migration or are setting up a fresh app:"
+printf '    %sRaycast → Settings → Extensions → Script Commands → Add Script Directory%s\n' "$DIM" "$RESET"
+printf '    %s→ select %s%s\n' "$DIM" "$SCRIPTS_LINK" "$RESET"
+
+exit 0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -85,7 +85,8 @@ dotfiles/
     │       ├── config/        # options, keymaps, autocmds, appearance
     │       └── plugins/       # One lazy.nvim spec per plugin concern
     ├── raycast/              # Raycast script commands (settings synced by Raycast Premium)
-    │   └── scripts/          # Script commands dir (symlinked to ~/.config/raycast/scripts)
+    │   └── scripts/          # Script commands dir (symlinked to ~/.config/raycast/scripts;
+    │                         #   shared by both v1 and the separate v2-beta app — see RUNBOOK)
     ├── ripgrep/
     ├── sheldon/              # Zsh plugin manager config
     ├── ssh/                  # SSH config template (private hosts in ~/.ssh/config.local)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -179,6 +179,8 @@ killall Dock                                                  # apply
 
 Open **Raycast Settings → Extensions → Script Commands → Add Script Directory** and select `~/.config/raycast/scripts`. This points Raycast at the dotfiles-managed script commands directory.
 
+If you also run the **Raycast v2 beta**, its "Migrate from Raycast v1" onboarding carries the script-directory registration across automatically (verified) — only re-add it by hand if you skip migration. See [Raycast script commands](#raycast-script-commands) below for the v1/v2 details. Run `raycast-doctor` any time to check symlink health.
+
 ### Quick reference
 
 | File | Purpose |
@@ -377,12 +379,30 @@ Bootstrap creates these directories automatically (`~/code/work/` only on work m
 
 Custom [Raycast script commands](https://github.com/raycast/script-commands) live in `config/raycast/scripts/`, symlinked to `~/.config/raycast/scripts/` by dotbot. Raycast settings, keybinds, and extensions are synced by Raycast Premium — only script commands are managed here.
 
-**One-time setup:** After running `./install`, open **Raycast Settings → Extensions → Script Commands → Add Script Directory** and select `~/.config/raycast/scripts`. This tells Raycast to scan that directory for script commands. You only need to do this once per machine.
+**One-time setup:** After running `./install`, open **Raycast Settings → Extensions → Script Commands → Add Script Directory** and select `~/.config/raycast/scripts`. This tells Raycast to scan that directory for script commands. You only need to do this once per app, per machine.
 
 **Current scripts:**
 - `quick-capture-obsidian.sh` — quick-capture a note to the Obsidian inbox
 
 A `script-command.template.sh` is included as a starting point for new scripts.
+
+#### Raycast v1 vs v2 beta
+
+Raycast ships the [v2 beta](https://www.raycast.com/new) as a **separate app** that coexists with v1 — different app bundles and bundle IDs, so neither can clobber the other:
+
+| | v1 | v2 beta |
+|------|------|------|
+| App | `/Applications/Raycast.app` | `/Applications/Raycast Beta.app` |
+| Bundle ID | `com.raycast.macos` | `com.raycast-x.macos` |
+| Settings store | `~/Library/Application Support/com.raycast.macos` | `…/com.raycast-x.macos` |
+| Homebrew | `cask "raycast"` | none yet — **manual install** from [raycast.com/new](https://www.raycast.com/new) (requires macOS Tahoe) |
+
+Key points:
+
+- **The Brewfile can't clobber the beta.** There is no `raycast@beta` cask, `brew bundle` runs with `--no-upgrade` (a no-op for the already-installed v1), and nothing in the install path runs `brew bundle cleanup`/`zap`, so the untracked beta app is never touched. `cask "raycast"` is intentionally kept — don't remove it to "clean up."
+- **Script commands are fully compatible.** They're plain shell with `@raycast.*` metadata comments; v2 supports the same format. The `~/.config/raycast/scripts` symlink is app-agnostic.
+- **Registration carries over on migration.** v2 has its own settings store, but its "Migrate from Raycast v1" onboarding brings the script-directory registration across automatically (verified — no manual action needed). If you skip migration, re-add `~/.config/raycast/scripts` under **Script Commands → Add Script Directory** inside the beta. This registration isn't stored in a readable location, so `raycast-doctor` can't verify it either way.
+- **`raycast-doctor`** (in `~/bin`) reports which apps are installed, checks the script-directory symlink, lists the tracked scripts, and prints the manual-registration reminder. Read-only; run it any time or on a new machine.
 
 ### Editors
 

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -102,7 +102,11 @@ cask "imageoptim"          # image optimizer
 cask "karabiner-elements"  # keyboard remapper (system extension)
 cask "obsidian"
 cask "plexamp"
-cask "raycast"
+cask "raycast"            # v1; kept alongside the manually-installed v2 beta
+                          # (com.raycast-x.macos — separate app, no cask exists
+                          # yet). Do NOT remove to "clean up": brew won't clobber
+                          # the beta, and this cask stays a no-op under
+                          # --no-upgrade. See `raycast-doctor` + docs/RUNBOOK.md.
 cask "steam"
 cask "thaw"                # menubar manager
 cask "visual-studio-code"


### PR DESCRIPTION
## Why

Migrating to the [Raycast v2 beta](https://www.raycast.com/new) raised two fears — that `brew bundle` would clobber the beta and reinstall v1, and that the dotfiles-managed `config/raycast/scripts/*` would break. Investigation (verified on a live machine) showed both are unfounded given how Raycast ships v2.

## Findings

- **v1 and v2 are separate apps.** v1 = `/Applications/Raycast.app` (`com.raycast.macos`); v2 beta = `/Applications/Raycast Beta.app` (`com.raycast-x.macos`), separate settings stores. They coexist by design — neither can clobber the other.
- **The Brewfile can't clobber the beta.** No `raycast@beta` cask exists (checked the Homebrew API), `brew bundle` runs `--no-upgrade` (a no-op for the installed v1), and nothing in the install path runs `cleanup`/`zap`. The beta is a manual install brew can't touch.
- **Script commands are compatible.** Plain shell + `@raycast.*` metadata; v2 supports the same format and the `~/.config/raycast/scripts` symlink is app-agnostic. The v1→v2 migration onboarding carries the script-directory registration over automatically (verified — no manual step needed).

## Changes

| File | Change |
|------|--------|
| `bin/raycast-doctor` | **New** read-only diagnostic (modeled on `brew-audit.sh`): detects installed v1/v2 apps, checks the scripts symlink, lists tracked commands, prints the per-app registration note. Auto-symlinked to `~/bin` via the existing `bin/*` glob. |
| `packages/Brewfile.universal` | Comment on `cask "raycast"` documenting the intentional v1/v2 coexistence so it isn't "cleaned up". |
| `docs/RUNBOOK.md` | New "Raycast v1 vs v2 beta" subsection (comparison table + key points) and a v2 note on the one-time setup step. |
| `docs/ARCHITECTURE.md` | Note the scripts dir is shared across both apps. |
| `SPEC.md` | Rotate Part B to this project. |

Applies across work and personal machines via the universal Brewfile + `bin/*` glob symlink.

## Testing

- `raycast-doctor` runs clean on a live machine with both apps installed (v1 + v2 beta detected, symlink healthy, `quick-capture-obsidian.sh` listed).
- `shellcheck` clean (also enforced by pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)