### PR TITLE
✨ Show ⌘-Tab app switcher on all displays

### DIFF
--- a/config/macos/defaults.sh
+++ b/config/macos/defaults.sh
@@ -81,6 +81,9 @@ defaults write com.apple.dock magnification -bool true
 defaults write com.apple.dock largesize -int 128
 setting "Enable Dock magnification (128px)"
 
+defaults write com.apple.dock appswitcher-all-displays -bool true
+setting "Show the ⌘-Tab app switcher on all displays"
+
 printf '\n'
 read -rp "  Remove all default Dock icons? (You can re-add apps later) [y/N] " wipe_dock
 if [[ "$wipe_dock" == [yY] ]]; then


### PR DESCRIPTION
## What

Add `defaults write com.apple.dock appswitcher-all-displays -bool true` to the Dock section of `config/macos/defaults.sh`, so the ⌘-Tab app switcher appears on **every** connected display rather than only the one whose Dock was most recently active.

## Why

Normalizes a setting that was previously only applied locally. Scoped universally rather than work-only: `defaults.sh` is a single universal script with no machine-scoping mechanism (only the `Brewfile.*` files split into universal/work/personal), and this is a harmless, generally-desirable preference — not worth inventing a new conditional layer for.

## Notes

- Applied on next run via the existing `killall Dock` at the end of the script.
- Idempotent, consistent with the surrounding Dock settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)