### PR TITLE
🐛 Fix tflint Brewfile entry: cask, not formula

### DIFF
--- a/packages/Brewfile.work
+++ b/packages/Brewfile.work
@@ -21,9 +21,9 @@ brew "aws/tap/eks-node-viewer"  # EKS node resource viewer
 tap "hashicorp/tap"
 brew "hashicorp/tap/packer"     # machine image building
 
-# tflint left homebrew-core; vendor ships it via their own tap
+# tflint left homebrew-core; vendor ships it as a cask via their own tap
 tap "terraform-linters/tap"
-brew "terraform-linters/tap/tflint"  # terraform linter
+cask "terraform-linters/tap/tflint"  # terraform linter
 
 brew "eksctl"         # AWS EKS CLI
 brew "k9s"            # Kubernetes TUI


### PR DESCRIPTION
## Problem

Running `./install` on a work machine failed with `No available formula with the name "terraform-linters/tap/tflint"`, even though the tap was declared and `brew search tflint` found it. Because `brew bundle` resolves the whole file up front, this one entry aborted the rest of `Brewfile.work`, leaving its other packages uninstalled.

## Root cause

`terraform-linters/tap` ships `tflint` as a **cask** (`Casks/tflint.rb`), but the Brewfile declared it with `brew "..."`, which only resolves formulae. `brew search` spans both formulae and casks, which masked the type mismatch.

## Fix

Change the entry from `brew "..."` to `cask "..."`. The tap was already correct — only the keyword was wrong.

Verified with `brew bundle check --file=packages/Brewfile.work`: `tflint` now resolves as a cask instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)