### PR TITLE
🧹 Undo uv installer's rc appends; track uv in Brewfile

### DIFF
--- a/config/bash/bashrc
+++ b/config/bash/bashrc
@@ -77,6 +77,11 @@ if [ -d /usr/local/sbin ] ; then
 	PATH="${PATH}:/usr/local/sbin"
 fi
 
+# ~/.local/bin (e.g. uv, pip --user installs)
+if [ -d "$HOME"/.local/bin ] ; then
+	PATH="$HOME/.local/bin:${PATH}"
+fi
+
 # Bash prompt
 PS1="\[\033[0;31m\][\$(date +%H:%M)]\[\033[0m\]\u@\h:\[\033[0;36m\]\W\[\033[0m\]\$ "
 

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -76,6 +76,7 @@ brew "wget"
 brew "httpie"
 brew "mise"           # version and venv manager
 brew "pipx"           # install Python CLI tools in isolated envs
+brew "uv"             # Python package/tool manager; provides the `qmk` shim
 brew "mkcert"         # local HTTPS certs
 brew "shellcheck"
 

--- a/packages/Brewfile.universal
+++ b/packages/Brewfile.universal
@@ -76,7 +76,7 @@ brew "wget"
 brew "httpie"
 brew "mise"           # version and venv manager
 brew "pipx"           # install Python CLI tools in isolated envs
-brew "uv"             # Python package/tool manager; provides the `qmk` shim
+brew "uv"             # Python package/tool manager
 brew "mkcert"         # local HTTPS certs
 brew "shellcheck"
 


### PR DESCRIPTION
## What happened

The `uv` standalone installer (run 2026-07-20) appended `. "$HOME/.local/bin/env"` to `~/.zshrc` and `~/.bashrc`. Both are dotbot symlinks, so the edit landed in this repo as uncommitted changes.

## Changes

**`zsh/zshrc.zsh`** — line removed. `zsh/lib/path.zsh:21-23` already prepends `~/.local/bin` with a directory guard, so it was pure duplication. File is byte-identical to its prior state.

**`config/bash/bashrc`** — bash genuinely had no `~/.local/bin` on PATH (its block only covered `~/bin`, `/usr/local/bin`, `/usr/local/sbin`), so the capability is kept — but written as a guarded block in the existing PATH section rather than sourcing uv's file. The installer's line is unguarded, so it errors on shell startup on any machine without uv present, which matters for the Linux remotes.

**`packages/Brewfile.universal`** — added `brew "uv"`. It had been installed standalone, so a fresh machine never got it, and the `qmk` shim in `~/.local/bin` is a uv tool that depends on it.

## Verification

- `zsh -n` / `bash -n` clean; pre-commit hooks pass.
- `uv` resolves to `~/.local/bin/uv` in both interactive zsh and bash after the change.

## Follow-ups (not in this PR)

- The standalone `~/.local/bin/uv` will shadow the brew-installed one, since `~/.local/bin` is prepended last. Worth removing the standalone binary after `brew install uv` so there's a single copy to keep updated.
- This class of problem recurs with any installer that edits rc files. `uv` and `rustup` both respect `INSTALLER_NO_MODIFY_PATH=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)