### PR TITLE
🧹 Trim derivable Key paths table from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,15 +18,7 @@ These must be respected when editing any shell config:
 2. **POSIX alias safety** — Do not alias standard POSIX commands (`ls`, `cat`, `grep`) to alter their output. Use new names (e.g., `ll` for `eza -l`).
 3. **Git config simplicity** — No exotic git hooks or `core.editor` behaviors that break automated commit workflows.
 
-## Key paths
+## Non-obvious paths
 
-| Path | Purpose |
-|------|---------|
-| `install.config.yaml` | Dotbot config — all symlinks and shell commands |
-| `zsh/zshrc.zsh` | Zsh entrypoint (symlinked to `~/.zshrc`) |
-| `zsh/lib/` | Modular zsh config, auto-sourced alphabetically |
-| `config/` | Tool configs symlinked to `~/.config/` |
-| `packages/Brewfile.*` | Homebrew packages (universal, work, personal) |
-| `docs/ARCHITECTURE.md` | Design source of truth |
-| `docs/RUNBOOK.md` | Usage, maintenance, troubleshooting |
-| `SPEC.md` | Current project task plan (rotates per project) |
+- `zsh/lib/` is auto-sourced alphabetically — filename order is load order.
+- `SPEC.md` is the current project's task plan and rotates per project.


### PR DESCRIPTION
## What

Replaces the 12-line **Key paths** table in `CLAUDE.md` with two lines covering only the facts the repo layout can't teach on its own.

## Why

`CLAUDE.md` loads into context on every session. The path table restated what `ls` and `install.config.yaml` already show — a fresh session reconstructs all of it with one directory listing, so it was paying rent without earning it.

Two entries in the table were genuinely non-obvious and are preserved:

- `zsh/lib/` is auto-sourced alphabetically, so filename order is load order.
- `SPEC.md` rotates per project.

The `docs/ARCHITECTURE.md` and `docs/RUNBOOK.md` pointers are already covered by the Repo overview section above the table.

Everything else in the file — workflow conventions, shell directives — is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)