### PR TITLE
✨ Show absolute token count in Claude Code statusline

### DIFF
--- a/config/claude/statusline-command.sh
+++ b/config/claude/statusline-command.sh
@@ -11,6 +11,9 @@ dir=$(basename "$cwd")
 model=$(echo "$input" | jq -r '.model.display_name // .model.id // "unknown"')
 
 used_pct=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+used_tokens=$(echo "$input" | jq -r '
+  (.context_window.total_input_tokens // 0) + (.context_window.total_output_tokens // 0)
+  | select(. > 0)')
 
 # --- Git branch ---
 git_branch=""
@@ -21,27 +24,42 @@ fi
 
 # --- Context bar ---
 bar_segment=""
-if [ -n "$used_pct" ]; then
-  pct_int=${used_pct%.*}
-  bar_width=20
-  filled=$(( pct_int * bar_width / 100 ))
-  empty=$(( bar_width - filled ))
-
-  # Color thresholds
-  if [ "$pct_int" -lt 50 ]; then
-    color="\033[32m"   # green
-  elif [ "$pct_int" -lt 75 ]; then
-    color="\033[33m"   # yellow
+if [ -n "$used_tokens" ]; then
+  # Color thresholds, by absolute token count
+  if [ "$used_tokens" -lt 100000 ]; then
+    color="\033[32m"          # green
+  elif [ "$used_tokens" -le 120000 ]; then
+    color="\033[38;5;208m"    # orange
   else
-    color="\033[31m"   # red
+    color="\033[31m"          # red
   fi
   reset="\033[0m"
 
-  bar=""
-  for i in $(seq 1 $filled); do bar="${bar}█"; done
-  for i in $(seq 1 $empty);  do bar="${bar}░"; done
+  # Human-readable count: 1234 -> 1.2k, 112499 -> 112.4k.
+  # Truncate rather than round, so a count below a color threshold never
+  # displays as if it had crossed it (99999 -> 99.9k, not 100.0k).
+  tokens_fmt=$(awk -v t="$used_tokens" 'BEGIN {
+    if (t < 1000)         printf "%d", t
+    else if (t < 1000000) printf "%.1fk", int(t / 100) / 10
+    else                  printf "%.2fM", int(t / 10000) / 100
+  }')
 
-  bar_segment="${color}[${bar}]${reset} ${pct_int}%"
+  # Bar still tracks how full the window is
+  bar=""
+  if [ -n "$used_pct" ]; then
+    pct_int=${used_pct%.*}
+    bar_width=20
+    filled=$(( pct_int * bar_width / 100 ))
+    [ "$filled" -gt "$bar_width" ] && filled=$bar_width
+    empty=$(( bar_width - filled ))
+
+    # Built with printf padding, not seq: macOS `seq 1 0` counts *down* and
+    # emits "1 0", which would add two stray blocks whenever a side is empty.
+    bar=$(printf "%${filled}s" | tr ' ' '█')$(printf "%${empty}s" | tr ' ' '░')
+    bar="[${bar}] "
+  fi
+
+  bar_segment="${color}${bar}${tokens_fmt}${reset}"
 fi
 
 # --- Assemble ---


### PR DESCRIPTION
## What

The Claude Code statusline showed context usage as a percentage of the window. On a 1M-context session that number stays tiny and uninformative, so this swaps it for the **actual token count**, colored by absolute usage:

| Tokens | Color |
| --- | --- |
| `< 100k` | green |
| `100k – 120k` | orange |
| `> 120k` | red |

The bar still tracks how full the window is by percentage, but takes the same color as the count so the whole segment reads as one signal.

Counts are **truncated rather than rounded**, so a value below a threshold never renders as though it had crossed one — 99,999 shows as a green `99.9k`, not a green `100.0k`.

## Bug fix

Also fixes a latent bar-width bug. The blocks were emitted with `for i in $(seq 1 $filled)`, but macOS `seq` counts *down* when the end is below the start — so `seq 1 0` yields `1 0` and appended two stray blocks whenever a side was empty, rendering a 22-character bar instead of 20. That fired constantly on a 1M-context session sitting near 0%. Rebuilt with `printf` padding + `tr`, and clamped `filled` to `bar_width`.

## Testing

Rendered across 500 → 1,000,000 tokens on both 200k and 1M windows:

- Bar is exactly 20 characters at every value, including 0% and 100%.
- Thresholds flip at the correct boundaries (99,999 green → 100,000 orange → 120,000 orange → 120,001 red).
- Formats as `999` / `1.0k` / `120.0k` / `1.00M`.
- Degrades cleanly when `context_window` is absent — the segment is simply omitted.

## Deploy

No action needed. `~/.claude/statusline-command.sh` is already symlinked to this file and `settings.json` already invokes it, so no `./install` or `claude-settings-build` rerun is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)